### PR TITLE
[add] DESIGN_DOC_TEMPLATEにPseudocode完全性ルールセクションを追加

### DIFF
--- a/.sdd/DESIGN_DOC_TEMPLATE.md
+++ b/.sdd/DESIGN_DOC_TEMPLATE.md
@@ -206,4 +206,28 @@ plugins/sdd-workflow/
 
 ---
 
+# Pseudocode の完全性ルール
+
+Design Doc に記載する pseudocode（データ構造・スクリプトの処理フロー等のコード例）は、
+**verbatim でコピーしても動作する完全性**を維持してください。
+実装への転記段階で細部が乖離すると、レビュー指摘や実行時エラーの原因になります。
+
+本リポジトリで使用する言語（Python / Bash）に合わせたルールを記載します。
+言語が増えた場合は sub-section を追加してください。
+
+## Python 共通
+
+- すべての import 文を明示する（型注釈で参照する型も含む）
+- `isinstance` チェックは BaseException 階層に注意（`asyncio.CancelledError` は Python 3.8+ で
+  `Exception` のサブクラスではない）
+- `x if x else fallback` の `x` が `""` / `[]` / `0` を取りうる場合は
+  `x if x is not None else fallback` で明示する
+
+## Bash / POSIX sh
+
+- shebang とオプション（`set -e` 等）を含めて記載し、POSIX 互換要件（macOS bash 3.2 / dash）を明示する
+- 外部コマンド（`jq` 等）への依存はコード例に含めて明示する
+
+---
+
 **この Design Docは、AIエージェントが実装（Implement）フェーズで参照する、具体的なコード生成のための指針となります。**

--- a/plugins/sdd-workflow/CHANGELOG.md
+++ b/plugins/sdd-workflow/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Verifies enum / CHECK constraint member-set completeness and requirement ID trace completeness
       (PRD <-> spec <-> design)
     - Added value drift sections to output templates (en/ja)
+- **`generate-spec`** - Added "Pseudocode Completeness Rules" section to design doc templates (`templates/{en,ja}/design_template.md`)
+    - Language-specific guidance (Python general / Pydantic v2 / SQLAlchemy & alembic) to keep design pseudocode copyable verbatim
+    - Extensible sub-section structure for additional languages (TypeScript / Go / Rust, etc.)
 
 ## [3.3.0] - 2026-03-02
 

--- a/plugins/sdd-workflow/skills/generate-spec/templates/en/design_template.md
+++ b/plugins/sdd-workflow/skills/generate-spec/templates/en/design_template.md
@@ -204,6 +204,36 @@ Modify the notation according to your project's programming language.
 
 ---
 
+# Pseudocode Completeness Rules
+
+Pseudocode in Design Docs (code examples for data models, interface definitions, processing flows, etc.)
+must remain **complete enough to be copied verbatim and still work**.
+When details diverge during transcription to implementation, they cause review findings and runtime errors.
+
+Select, adapt, and extend the following according to the languages used in your project
+(keep the structure extensible with sub-sections for TypeScript / Go / Rust, etc.).
+
+## Python (General)
+
+- Make all import statements explicit (including types referenced only in type annotations)
+- Be careful with `isinstance` checks and the BaseException hierarchy
+  (`asyncio.CancelledError` is not a subclass of `Exception` in Python 3.8+)
+- When `x` in `x if x else fallback` can be `""` / `[]` / `0`,
+  write `x if x is not None else fallback` explicitly
+
+## Pydantic v2
+
+- When reassigning inside `model_validator(mode='after')` on a model with `frozen=True`,
+  use `object.__setattr__(self, ...)`
+- `default_factory` is evaluated after `mode='before'` validators (mind the ordering)
+
+## SQLAlchemy / alembic
+
+- Keep alembic revision IDs ≤ 32 characters (`alembic_version.version_num` is `varchar(32)`)
+- Write CHECK constraints with conditions that do not block transitions (use auxiliary columns)
+
+---
+
 # Customization Guidelines for Projects
 
 When customizing this template for your project, update the following:
@@ -213,6 +243,7 @@ When customizing this template for your project, update the following:
 3. **Change history code examples**: Adjust to project's programming language
 4. **Module structure table columns**: Adjust to project's structure (package/module organization)
 5. **Technology stack table**: Adjust to technology areas used in the project
+6. **Pseudocode completeness rules**: Select and extend rules according to the pitfalls of the languages and frameworks used in the project
 
 ---
 

--- a/plugins/sdd-workflow/skills/generate-spec/templates/ja/design_template.md
+++ b/plugins/sdd-workflow/skills/generate-spec/templates/ja/design_template.md
@@ -204,6 +204,36 @@ interface SomeRepository {
 
 ---
 
+# Pseudocode の完全性ルール
+
+Design Doc に記載する pseudocode（データモデル・インターフェース定義・処理フロー等のコード例）は、
+**verbatim でコピーしても動作する完全性**を維持してください。
+実装への転記段階で細部が乖離すると、レビュー指摘や実行時エラーの原因になります。
+
+以下はプロジェクトで使用する言語に合わせて取捨選択・追加してください（TypeScript / Go / Rust 等の
+sub-section を増やせる形を維持すること）。
+
+## Python 共通
+
+- すべての import 文を明示する（型注釈で参照する型も含む）
+- `isinstance` チェックは BaseException 階層に注意（`asyncio.CancelledError` は Python 3.8+ で
+  `Exception` のサブクラスではない）
+- `x if x else fallback` の `x` が `""` / `[]` / `0` を取りうる場合は
+  `x if x is not None else fallback` で明示する
+
+## Pydantic v2
+
+- `frozen=True` のモデルで `model_validator(mode='after')` 内に再代入する場合は
+  `object.__setattr__(self, ...)` を使用する
+- `default_factory` は `mode='before'` validator の後に評価される（順序に注意）
+
+## SQLAlchemy / alembic
+
+- alembic revision ID は 32 文字以下にする（`alembic_version.version_num` が `varchar(32)`）
+- CHECK 制約は遷移を妨げない条件で書く（補助カラムを併用）
+
+---
+
 # プロジェクトへのカスタマイズ指針
 
 このテンプレートをプロジェクト用にカスタマイズする際は、以下の項目を更新してください：
@@ -213,6 +243,7 @@ interface SomeRepository {
 3. **変更履歴のコード例**: プロジェクトのプログラミング言語に合わせる
 4. **モジュール分割表のカラム**: プロジェクトの構成（パッケージ/モジュール構造）に合わせる
 5. **技術スタック表**: プロジェクトで使用する技術領域に合わせる
+6. **Pseudocode の完全性ルール**: プロジェクトで使用する言語・フレームワークの落とし穴に合わせて取捨選択・追加する
 
 ---
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

design doc の pseudocode が実装への転記段階で細部乖離（import 漏れ、BaseException 階層の取り逃し、falsy 値による fallback 誤発火、alembic revision ID の varchar(32) 超過等）を起こす問題を防ぐため、DESIGN_DOC_TEMPLATE に「Pseudocode の完全性ルール」セクションを追加します。

Closes #49

## 変更内容

- [x] `plugins/sdd-workflow/skills/generate-spec/templates/ja/design_template.md` に「Pseudocode の完全性ルール」セクション（Python 共通 / Pydantic v2 / SQLAlchemy・alembic）を追加
- [x] 同 `templates/en/design_template.md` に英語版セクションを追加
- [x] 両テンプレートの「プロジェクトへのカスタマイズ指針」に言語別ルールの取捨選択・追加の項目を追記
- [x] 本リポジトリの `.sdd/DESIGN_DOC_TEMPLATE.md` にリポジトリ実態（Python / Bash）に合わせたルールを追加
- [x] `CHANGELOG.md` の [Unreleased] にエントリを追加

## レビューの焦点

- Issue #49 提案のルール内容（Python / Pydantic v2 / SQLAlchemy・alembic）が過不足なく反映されているか
- 言語ごとに sub-section を増やせる構成（TypeScript / Go / Rust 等への拡張性）になっているか
- `.sdd/DESIGN_DOC_TEMPLATE.md` は本リポジトリ向けカスタマイズ版のため、Pydantic/SQLAlchemy を含めず Python 共通 + Bash/POSIX sh に絞った判断の妥当性

## テスト計画

- [x] `cat plugins/*/.claude-plugin/*.json | jq .` JSON構文チェック通過（変更なしのため既存どおり）
- [x] `scripts/plugin-lint.sh` エラー 0 で通過（warning は既存 SKILL.md 由来）
- [x] `scripts/validate-marketplace.sh` 全チェック通過
- [x] Markdownリンクの整合性確認（追加セクションにリンクなし）

## 参考資料

- Issue #49


<!-- for GitHub Copilot review rule -->

<details>
<summary>for GitHub Copilot review rule</summary>

## お願い

- 日本語で回答してください
- 簡潔で分かりやすい説明を心がけてください
- ベストプラクティスの具体例を提示してください
- 指摘の根拠となる情報源や学習リソースの提案を積極的に行ってください

## レビュールール

以下のプレフィックスを使用してレビューコメントを分類してください：

- `[must]` - 必須修正項目（セキュリティ、バグ、重大な設計問題）
- `[recommend]` - 推奨修正項目（パフォーマンス、可読性の大幅改善）
- `[nits]` - 軽微な指摘（コードスタイル、タイポ等）

## レビューステップ

1. コードの差分よりPRの概要を作成する

2. 実際にコードを確認し、以下の観点でレビューを行う
  - コードの正確性
  - パフォーマンス
  - セキュリティ
  - 可読性
  - 保守性
  - コーディング規約の遵守

3. 必要に応じて、具体的な改善点を指摘する

</details>

<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)