### PR TITLE
[add] plugin.json に agents/skills/hooks のコンポーネントパスを明示指定

### DIFF
--- a/plugins/sdd-workflow/.claude-plugin/plugin.json
+++ b/plugins/sdd-workflow/.claude-plugin/plugin.json
@@ -6,5 +6,14 @@
     "name": "toshiki.imagawa",
     "url": "https://github.com/ToshikiImagawa"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "agents": [
+    "./agents/clarification-assistant.md",
+    "./agents/front-matter-reviewer.md",
+    "./agents/prd-reviewer.md",
+    "./agents/requirement-analyzer.md",
+    "./agents/spec-reviewer.md"
+  ],
+  "skills": "./skills",
+  "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

`plugins/sdd-workflow/.claude-plugin/plugin.json` はこれまでディレクトリ規約による暗黙的 discovery に依存していたため、`agents`/`skills`/`hooks` のコンポーネントパスをマニフェストに明示し、構成の可読性・保守性を高める。

Closes #52

## 変更内容

- [x] `plugin.json` に `agents` フィールドを追加（`claude plugin validate` のスキーマが個別ファイルパスの配列を要求するため、5 エージェントの `.md` を列挙）
- [x] `plugin.json` に `skills: "./skills"` を追加
- [x] `plugin.json` に `hooks: "./hooks/hooks.json"` を追加

## レビューの焦点

- `agents` をディレクトリ文字列 (`"./agents"`) にすると `claude plugin validate` が `Invalid input` で失敗するため、ファイルパス配列形式を採用した点（PLUGIN.md 記載の string 形式と実際のスキーマの差異）
- 存在しないコンポーネント（`commands`/`mcpServers`/`lspServers`/`outputStyles`）は追加していない点

## テスト計画

- [x] `cat plugins/*/.claude-plugin/*.json | jq .` JSON構文チェック通過
- [x] `scripts/validate-marketplace.sh` 通過（`claude plugin validate` 含む）
- [x] `scripts/plugin-lint.sh` 通過（Errors: 0）
- [ ] `claude --plugin-dir ./plugins/sdd-workflow` でローカルテスト確認

## 参考資料

- #52
- PLUGIN.md「コンポーネントパスフィールド」節

<!-- for GitHub Copilot review rule -->

<details>
<summary>for GitHub Copilot review rule</summary>

## お願い

- 日本語で回答してください
- 簡潔で分かりやすい説明を心がけてください
- ベストプラクティスの具体例を提示してください
- 指摘の根拠となる情報源や学習リソースの提案を積極的に行ってください

## レビュールール

以下のプレフィックスを使用してレビューコメントを分類してください：

- `[must]` - 必須修正項目（セキュリティ、バグ、重大な設計問題）
- `[recommend]` - 推奨修正項目（パフォーマンス、可読性の大幅改善）
- `[nits]` - 軽微な指摘（コードスタイル、タイポ等）

## レビューステップ

1. コードの差分よりPRの概要を作成する

2. 実際にコードを確認し、以下の観点でレビューを行う
  - コードの正確性
  - パフォーマンス
  - セキュリティ
  - 可読性
  - 保守性
  - コーディング規約の遵守

3. 必要に応じて、具体的な改善点を指摘する

</details>

<!-- for GitHub Copilot review rule -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)