### PR TITLE
[add] hooks.json の活用範囲を SessionStart 以外に拡大 (#54)

### DIFF
--- a/.claude/rules/repository-structure.md
+++ b/.claude/rules/repository-structure.md
@@ -36,7 +36,11 @@ ai-sdd-workflow/
 │       ├── hooks/
 │       │   └── hooks.json         # フック設定（JSON形式）
 │       ├── scripts/
-│       │   └── session-start.py   # セッション開始時の初期化
+│       │   ├── session-start.py   # セッション開始時の初期化
+│       │   ├── hook_common.py     # フックスクリプト共通ヘルパー
+│       │   ├── user-prompt-submit.py  # Vibe Coding兆候検知
+│       │   ├── pre-tool-use.py    # .sdd/ ファイル命名規則検証
+│       │   └── post-tool-use.py   # ドキュメント更新漏れ検知
 │       ├── AI-SDD-PRINCIPLES.source.md
 │       ├── LICENSE
 │       ├── README.md

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -13,6 +13,7 @@ paths:
 | `validate-marketplace.sh` | `marketplace.json` / `plugin.json` のJSON構文・必須フィールド・バージョン整合性を検証     | `validate`    |
 | `plugin-lint.sh`          | `.claude/skills/plugin-lint/SKILL.md` の検査内容を実装。プロンプトMD内の不適切なコードブロックやファイル命名規則を検証 | `plugin-lint` |
 | `test-session-start.sh`   | `plugins/sdd-workflow/scripts/session-start.py` のゴールデンファイル回帰テスト     | `test`        |
+| `test-hook-scripts.sh`    | `plugins/sdd-workflow/scripts/` のフックスクリプト（pre-tool-use / post-tool-use / user-prompt-submit）の回帰テスト | `test`        |
 
 ## 実装・修正時の注意
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: bash scripts/plugin-lint.sh
 
   test:
-    name: Test session-start.py (${{ matrix.os }})
+    name: Test hook scripts (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -52,3 +52,5 @@ jobs:
           python-version: '3.x'
       - name: Run session-start regression tests
         run: bash scripts/test-session-start.sh
+      - name: Run hook scripts regression tests
+        run: bash scripts/test-hook-scripts.sh

--- a/plugins/sdd-workflow/CHANGELOG.md
+++ b/plugins/sdd-workflow/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Hooks
+
+- Expanded `hooks.json` beyond `SessionStart` ([#54](https://github.com/ToshikiImagawa/ai-sdd-workflow/issues/54))
+    - **`UserPromptSubmit`** (`scripts/user-prompt-submit.py`) - Detects Vibe Coding signals (vague instructions such
+      as "make it nice" / "いい感じに") in the user prompt and injects additional context prompting a vibe-detector
+      style clarification flow (detection only, never blocks)
+    - **`PreToolUse`** (`scripts/pre-tool-use.py`, matcher `Write|Edit|MultiEdit`) - Validates AI-SDD file naming
+      conventions before writing under `.sdd/` (requirement: no suffix, specification: `_spec.md` / `_design.md`
+      required) and blocks violating writes
+    - **`PostToolUse`** (`scripts/post-tool-use.py`, matcher `Write|Edit|MultiEdit`) - Detects potential document
+      update omissions: reminds to run consistency checks after `.sdd/` document edits, and reminds to sync the
+      design doc after editing a source file with a matching `*_design.md`
+    - Added `scripts/hook_common.py` (shared helpers) and `scripts/test-hook-scripts.sh` regression tests (CI `test` job)
+
 #### Agents
 
 - **`requirement-analyzer`** - Added ID numbering validation (`--validate-ids`, also runs as part of `--analyze`)

--- a/plugins/sdd-workflow/README.md
+++ b/plugins/sdd-workflow/README.md
@@ -20,7 +20,7 @@ as the source of truth. Supports multiple languages via `SDD_LANG` configuration
 | macOS       |    ✅    | Fully supported                        |
 | Linux       |    ✅    | Fully supported                        |
 | Windows     |    ❌    | Not supported (see alternatives below) |
-| Python      |  3.7+   | Required for session-start hook        |
+| Python      |  3.7+   | Required for hook scripts              |
 
 ### Windows Limitations
 
@@ -145,6 +145,9 @@ This command automatically:
 | Hook            | Trigger      | Description                                                                         |
 |:----------------|:-------------|:------------------------------------------------------------------------------------|
 | `session-start` | SessionStart | Loads settings from `.sdd-config.json` and sets environment variables automatically |
+| `user-prompt-submit` | UserPromptSubmit | Detects Vibe Coding signals (vague instructions) in the user prompt and injects a clarification reminder |
+| `pre-tool-use`  | PreToolUse (Write/Edit) | Blocks writes to `.sdd/` documents that violate file naming conventions |
+| `post-tool-use` | PostToolUse (Write/Edit) | Reminds about document consistency checks after editing `.sdd/` docs or source files with a matching design doc |
 
 **Note**: Hooks are automatically enabled when the plugin is installed. No additional configuration is required.
 
@@ -355,6 +358,9 @@ This plugin automatically loads `.sdd-config.json` and sets environment variable
 | Hook            | Trigger      | Description                                                           |
 |:----------------|:-------------|:----------------------------------------------------------------------|
 | `session-start` | SessionStart | Loads settings from `.sdd-config.json` and sets environment variables |
+| `user-prompt-submit` | UserPromptSubmit | Detects Vibe Coding signals (vague instructions) in the user prompt and injects a clarification reminder |
+| `pre-tool-use`  | PreToolUse (Write/Edit) | Blocks writes to `.sdd/` documents that violate file naming conventions |
+| `post-tool-use` | PostToolUse (Write/Edit) | Reminds about document consistency checks after editing `.sdd/` docs or source files with a matching design doc |
 
 ### Environment Variables Set
 
@@ -576,7 +582,11 @@ sdd-workflow/
 ├── hooks/
 │   └── hooks.json                 # Hooks configuration
 ├── scripts/
-│   └── session-start.py           # Session start initialization script
+│   ├── session-start.py           # Session start initialization script
+│   ├── hook_common.py             # Shared helpers for hook scripts
+│   ├── user-prompt-submit.py      # Vibe Coding signal detection
+│   ├── pre-tool-use.py            # .sdd/ file naming validation
+│   └── post-tool-use.py           # Document update omission detection
 ├── AI-SDD-PRINCIPLES.source.md
 ├── LICENSE
 ├── README.md

--- a/plugins/sdd-workflow/hooks/hooks.json
+++ b/plugins/sdd-workflow/hooks/hooks.json
@@ -9,6 +9,38 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.py"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-use.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/sdd-workflow/scripts/hook_common.py
+++ b/plugins/sdd-workflow/scripts/hook_common.py
@@ -1,0 +1,68 @@
+"""hook_common.py - Shared helpers for hook scripts.
+
+Provides stdin JSON parsing, project root resolution,
+.sdd-config.json loading, and hook output emission.
+"""
+
+import json
+import os
+import sys
+from typing import Any, Dict, Tuple
+
+
+def read_stdin_json() -> Dict[str, Any]:
+    try:
+        data = json.load(sys.stdin)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
+def get_project_root(payload: Dict[str, Any]) -> str:
+    cwd = payload.get("cwd", "")
+    if cwd and os.path.isdir(cwd):
+        return cwd
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if project_dir:
+        return project_dir
+    return os.getcwd()
+
+
+def load_sdd_paths(project_root: str) -> Tuple[str, str, str]:
+    """Return (sdd_root, requirement_dir, specification_dir) names."""
+    root = ".sdd"
+    requirement_dir = "requirement"
+    specification_dir = "specification"
+    config_path = os.path.join(project_root, ".sdd-config.json")
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                raw = json.load(f)
+            if raw.get("root"):
+                root = raw["root"]
+            dirs = raw.get("directories", {})
+            if dirs.get("requirement"):
+                requirement_dir = dirs["requirement"]
+            if dirs.get("specification"):
+                specification_dir = dirs["specification"]
+        except (json.JSONDecodeError, OSError):
+            pass
+    return root, requirement_dir, specification_dir
+
+
+def emit_additional_context(event_name: str, text: str) -> None:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "additionalContext": text,
+        },
+    }, ensure_ascii=False))
+
+
+def relative_to_project(file_path: str, project_root: str) -> str:
+    """Return file_path relative to project_root, or '' if outside."""
+    abs_path = os.path.abspath(file_path)
+    abs_root = os.path.abspath(project_root)
+    if not abs_path.startswith(abs_root + os.sep):
+        return ""
+    return os.path.relpath(abs_path, abs_root)

--- a/plugins/sdd-workflow/scripts/post-tool-use.py
+++ b/plugins/sdd-workflow/scripts/post-tool-use.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""post-tool-use.py - PostToolUse hook script (Write|Edit|MultiEdit).
+
+Detects potential document update omissions after a file edit:
+- .sdd document edited: reminds to check PRD <-> spec <-> design consistency
+- source file edited with a matching *_design.md: reminds to keep the design doc in sync
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from hook_common import (  # noqa: E402
+    emit_additional_context,
+    get_project_root,
+    load_sdd_paths,
+    read_stdin_json,
+    relative_to_project,
+)
+
+SOURCE_EXTENSIONS = (
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java",
+    ".kt", ".swift", ".cs", ".rb", ".php", ".c", ".cc", ".cpp", ".h",
+)
+
+
+def find_design_doc(spec_dir: str, stem: str) -> str:
+    """Return the relative path of {stem}_design.md under spec_dir, or ''."""
+    target = f"{stem}_design.md"
+    for dirpath, _dirnames, filenames in os.walk(spec_dir):
+        if target in filenames:
+            return os.path.join(dirpath, target)
+    return ""
+
+
+def main() -> None:
+    payload = read_stdin_json()
+    file_path = payload.get("tool_input", {}).get("file_path", "")
+    if not file_path:
+        return
+
+    project_root = get_project_root(payload)
+    rel_path = relative_to_project(file_path, project_root)
+    if not rel_path:
+        return
+
+    sdd_root, requirement_dir, specification_dir = load_sdd_paths(project_root)
+    requirement_prefix = os.path.join(sdd_root, requirement_dir)
+    specification_prefix = os.path.join(sdd_root, specification_dir)
+
+    if rel_path.startswith(specification_prefix + os.sep) and rel_path.endswith(".md"):
+        emit_additional_context(
+            "PostToolUse",
+            f"[AI-SDD] '{rel_path}' was updated. Verify consistency across "
+            "PRD <-> *_spec.md <-> *_design.md (requirement ID references, data models, "
+            "API definitions). Consider running the doc-consistency-checker skill.",
+        )
+        return
+
+    if rel_path.startswith(requirement_prefix + os.sep) and rel_path.endswith(".md"):
+        emit_additional_context(
+            "PostToolUse",
+            f"[AI-SDD] '{rel_path}' (PRD) was updated. Verify that downstream "
+            "*_spec.md / *_design.md documents reflect the change "
+            "(new/changed UR/FR/NFR must propagate). Consider running the "
+            "doc-consistency-checker skill.",
+        )
+        return
+
+    if rel_path.startswith(sdd_root + os.sep):
+        return
+
+    _root, ext = os.path.splitext(rel_path)
+    if ext not in SOURCE_EXTENSIONS:
+        return
+
+    spec_dir = os.path.join(project_root, specification_prefix)
+    if not os.path.isdir(spec_dir):
+        return
+
+    stem = os.path.basename(rel_path)[: -len(ext)]
+    design_doc = find_design_doc(spec_dir, stem)
+    if design_doc:
+        design_rel = os.path.relpath(design_doc, project_root)
+        emit_additional_context(
+            "PostToolUse",
+            f"[AI-SDD] '{rel_path}' was updated and a matching design document "
+            f"'{design_rel}' exists. If the implementation behavior changed, "
+            "update the design document to keep it as the source of truth.",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sdd-workflow/scripts/pre-tool-use.py
+++ b/plugins/sdd-workflow/scripts/pre-tool-use.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""pre-tool-use.py - PreToolUse hook script (Write|Edit|MultiEdit).
+
+Validates AI-SDD file naming conventions before writing to .sdd/ documents:
+- requirement/: no _spec/_design suffix allowed
+- specification/: _spec.md or _design.md suffix required
+
+Blocks the tool call (exit 2) on violation.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from hook_common import (  # noqa: E402
+    get_project_root,
+    load_sdd_paths,
+    read_stdin_json,
+    relative_to_project,
+)
+
+
+def validate_naming(rel_path: str, requirement_prefix: str, specification_prefix: str) -> str:
+    """Return an error message if rel_path violates naming conventions, else ''."""
+    if not rel_path.endswith(".md"):
+        return ""
+    stem = os.path.basename(rel_path)[: -len(".md")]
+
+    if rel_path.startswith(requirement_prefix + os.sep):
+        if stem.endswith("_spec") or stem.endswith("_design"):
+            return (
+                f"[AI-SDD] Naming violation: '{rel_path}'. "
+                "Files under requirement/ must not have a _spec/_design suffix "
+                "(e.g. user-login.md, index.md)."
+            )
+    elif rel_path.startswith(specification_prefix + os.sep):
+        if not (stem.endswith("_spec") or stem.endswith("_design")):
+            return (
+                f"[AI-SDD] Naming violation: '{rel_path}'. "
+                "Files under specification/ require a _spec.md or _design.md suffix "
+                "(e.g. user-login_spec.md, index_design.md)."
+            )
+    return ""
+
+
+def main() -> None:
+    payload = read_stdin_json()
+    file_path = payload.get("tool_input", {}).get("file_path", "")
+    if not file_path:
+        return
+
+    project_root = get_project_root(payload)
+    rel_path = relative_to_project(file_path, project_root)
+    if not rel_path:
+        return
+
+    sdd_root, requirement_dir, specification_dir = load_sdd_paths(project_root)
+    requirement_prefix = os.path.join(sdd_root, requirement_dir)
+    specification_prefix = os.path.join(sdd_root, specification_dir)
+
+    error = validate_naming(rel_path, requirement_prefix, specification_prefix)
+    if error:
+        print(error, file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sdd-workflow/scripts/user-prompt-submit.py
+++ b/plugins/sdd-workflow/scripts/user-prompt-submit.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""user-prompt-submit.py - UserPromptSubmit hook script.
+
+Detects Vibe Coding signals (vague instructions) in the user prompt
+and injects additional context prompting a vibe-detector style analysis.
+Detection only; never blocks the prompt.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from hook_common import emit_additional_context, read_stdin_json  # noqa: E402
+
+# (label, regex) pairs based on the vibe-detector skill detection patterns
+VAGUE_PATTERNS = [
+    ("subjective expression", r"いい感じ|よしなに|なんとなく|それっぽく|うまいこと|うまくやって"),
+    ("subjective expression", r"\bmake it (nice|work|pretty|look good)\b|\bsomehow\b"),
+    ("unclear degree", r"とりあえず動|ざっくり|適当に|少し(速く|良く)|もうちょっと"),
+    ("unclear degree", r"\broughly working\b|\ba bit (faster|better)\b"),
+    ("ambiguous scope / implicit assumption", r"前と同じ|いつもの|例のやつ|例の(機能|あれ)|さっきの感じ"),
+    ("ambiguous scope / implicit assumption", r"\bsame as (before|last time)\b|\bas usual\b|\bthe usual\b"),
+    ("ambiguous priority", r"できれば|ついでに|時間があれば|余裕があれば"),
+    ("ambiguous priority", r"\bif possible\b|\bwhile you're at it\b|\bwhen you have time\b"),
+]
+
+
+def detect_vague_expressions(prompt: str) -> list:
+    matched = []
+    for label, pattern in VAGUE_PATTERNS:
+        m = re.search(pattern, prompt, re.IGNORECASE)
+        if m:
+            matched.append(f"{label}: \"{m.group(0)}\"")
+    return matched
+
+
+def main() -> None:
+    payload = read_stdin_json()
+    prompt = payload.get("prompt", "")
+    if not prompt:
+        return
+
+    matched = detect_vague_expressions(prompt)
+    if not matched:
+        return
+
+    findings = "\n".join(f"- {item}" for item in matched)
+    emit_additional_context(
+        "UserPromptSubmit",
+        "[AI-SDD] Potential Vibe Coding signals detected in the user prompt:\n"
+        f"{findings}\n"
+        "Before implementing, follow the vibe-detector skill flow: assess the risk level, "
+        "clarify ambiguous points with the user (or via the clarify skill), and check "
+        "existing specifications under the SDD specification directory.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-hook-scripts.sh
+++ b/scripts/test-hook-scripts.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+# test-hook-scripts.sh
+# Regression tests for plugins/sdd-workflow/scripts/{pre-tool-use,post-tool-use,user-prompt-submit}.py
+# POSIX compatible (macOS bash 3.2 / dash)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK_SCRIPTS_DIR="${REPO_ROOT}/plugins/sdd-workflow/scripts"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    NC=''
+fi
+
+log_pass() {
+    printf '%sPASS%s %s\n' "$GREEN" "$NC" "$1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+log_fail() {
+    printf '%sFAIL%s %s\n' "$RED" "$NC" "$1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+TMP_DIR=""
+# shellcheck disable=SC2329
+cleanup() {
+    if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# Set up a fake project with .sdd structure
+TMP_DIR="$(mktemp -d)"
+mkdir -p "$TMP_DIR/.sdd/requirement" "$TMP_DIR/.sdd/specification/auth" "$TMP_DIR/src"
+touch "$TMP_DIR/.sdd/specification/auth/user-login_design.md"
+
+# run_hook <test-name> <script> <stdin-json> <expected-exit> <expected-output-substring>
+# expected-output-substring empty means stdout must be empty
+run_hook() {
+    name="$1"
+    script="$2"
+    stdin_json="$3"
+    expected_exit="$4"
+    expected_substr="$5"
+
+    set +e
+    output=$(printf '%s' "$stdin_json" | python3 "${HOOK_SCRIPTS_DIR}/${script}" 2>&1)
+    actual_exit=$?
+    set -e
+
+    if [ "$actual_exit" -ne "$expected_exit" ]; then
+        log_fail "${name}: exit code ${actual_exit} (expected ${expected_exit})"
+        return
+    fi
+    if [ -n "$expected_substr" ]; then
+        case "$output" in
+            *"$expected_substr"*) ;;
+            *)
+                log_fail "${name}: output missing '${expected_substr}' (got: ${output})"
+                return
+                ;;
+        esac
+    else
+        if [ -n "$output" ]; then
+            log_fail "${name}: expected empty output (got: ${output})"
+            return
+        fi
+    fi
+    log_pass "$name"
+}
+
+echo "=== pre-tool-use.py ==="
+
+run_hook "pre: valid spec name passes" "pre-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/specification/user-login_spec.md\"}}" \
+    0 ""
+
+run_hook "pre: specification without suffix is blocked" "pre-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/specification/user-login.md\"}}" \
+    2 "Naming violation"
+
+run_hook "pre: requirement with _spec suffix is blocked" "pre-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/requirement/user-login_spec.md\"}}" \
+    2 "Naming violation"
+
+run_hook "pre: requirement without suffix passes" "pre-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/requirement/user-login.md\"}}" \
+    0 ""
+
+run_hook "pre: non-sdd file passes" "pre-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/src/main.py\"}}" \
+    0 ""
+
+run_hook "pre: invalid stdin is a no-op" "pre-tool-use.py" \
+    "not-json" \
+    0 ""
+
+echo "=== post-tool-use.py ==="
+
+run_hook "post: spec edit reminds consistency check" "post-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/specification/auth/user-login_spec.md\"}}" \
+    0 "doc-consistency-checker"
+
+run_hook "post: PRD edit reminds downstream propagation" "post-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/requirement/user-login.md\"}}" \
+    0 "downstream"
+
+run_hook "post: source edit with matching design doc reminds sync" "post-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/src/user-login.py\"}}" \
+    0 "user-login_design.md"
+
+run_hook "post: source edit without design doc is silent" "post-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/src/main.py\"}}" \
+    0 ""
+
+echo "=== user-prompt-submit.py ==="
+
+run_hook "prompt: vague ja expression is detected" "user-prompt-submit.py" \
+    "{\"prompt\": \"いい感じに直して\"}" \
+    0 "Vibe Coding"
+
+run_hook "prompt: vague en expression is detected" "user-prompt-submit.py" \
+    "{\"prompt\": \"just make it work somehow\"}" \
+    0 "Vibe Coding"
+
+run_hook "prompt: clear instruction is silent" "user-prompt-submit.py" \
+    "{\"prompt\": \"Add a --verbose flag to session-start.py that logs config values\"}" \
+    0 ""
+
+echo ""
+echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

`plugins/sdd-workflow/hooks/hooks.json` は従来 `SessionStart` のみでしたが、Issue #54 の提案に沿って `UserPromptSubmit` / `PreToolUse` / `PostToolUse` フックを追加し、AI-SDD ワークフローの自動ガードを拡大します。

Closes #54

## 変更内容

- [x] `UserPromptSubmit` フック追加（`scripts/user-prompt-submit.py`）: プロンプト中の Vibe Coding 兆候（「いい感じに」「somehow」等の曖昧表現）をパターン検知し、vibe-detector skill 相当の明確化フローを促す additionalContext を注入（検知のみ、ブロックしない）
- [x] `PreToolUse` フック追加（`scripts/pre-tool-use.py`、matcher: `Write|Edit|MultiEdit`）: `.sdd/` 配下への書き込み前にファイル命名規則（requirement はサフィックスなし、specification は `_spec.md`/`_design.md` 必須）を検証し、違反時は exit 2 でブロック
- [x] `PostToolUse` フック追加（`scripts/post-tool-use.py`、matcher: `Write|Edit|MultiEdit`）: `.sdd/` ドキュメント編集後に doc-consistency-checker によるトレーサビリティ確認をリマインド。対応する `*_design.md` が存在するソースファイル編集後には設計書同期をリマインド
- [x] `scripts/hook_common.py`: stdin JSON 解析・`.sdd-config.json` 読み込み等の共通ヘルパー
- [x] `scripts/test-hook-scripts.sh`: 3 スクリプトの回帰テスト（13 ケース）を追加し、CI の `test` ジョブに登録
- [x] ドキュメント更新: プラグイン README（フック一覧・構成図）、CHANGELOG（Unreleased）、`.claude/rules/scripts.md`・`repository-structure.md`

## レビューの焦点

- `plugins/sdd-workflow/hooks/hooks.json` の matcher 設定（`Write|Edit|MultiEdit`）と既存 `SessionStart` 形式との整合性
- `pre-tool-use.py` のブロック条件が CLAUDE.md の命名規則と一致しているか
- `user-prompt-submit.py` の検知パターン（ja/en）が vibe-detector skill の検出パターン表と整合しているか（誤検知/検知漏れのバランス）
- `post-tool-use.py` のソースファイル → 設計書マッチング（basename stem と `{stem}_design.md` の一致）というヒューリスティックの妥当性

## テスト計画

- [x] `cat plugins/*/.claude-plugin/*.json | jq .` JSON構文チェック通過
- [x] `bash scripts/test-hook-scripts.sh` 13 ケース全パス
- [x] `bash scripts/test-session-start.sh` 7 ケース全パス（既存回帰なし）
- [x] `bash scripts/plugin-lint.sh` / `bash scripts/validate-marketplace.sh` 通過
- [x] `shellcheck -S warning -e SC1091 scripts/*.sh` 通過
- [ ] `claude --plugin-dir ./plugins/sdd-workflow` でフック発火の手動確認

## 参考資料

- Issue: https://github.com/ToshikiImagawa/ai-sdd-workflow/issues/54
- PLUGIN.md「フック (Hooks)」セクション（イベント一覧・設定形式）


<!-- for GitHub Copilot review rule -->

<details>
<summary>for GitHub Copilot review rule</summary>

## お願い

- 日本語で回答してください
- 簡潔で分かりやすい説明を心がけてください
- ベストプラクティスの具体例を提示してください
- 指摘の根拠となる情報源や学習リソースの提案を積極的に行ってください

## レビュールール

以下のプレフィックスを使用してレビューコメントを分類してください：

- `[must]` - 必須修正項目（セキュリティ、バグ、重大な設計問題）
- `[recommend]` - 推奨修正項目（パフォーマンス、可読性の大幅改善）
- `[nits]` - 軽微な指摘（コードスタイル、タイポ等）

## レビューステップ

1. コードの差分よりPRの概要を作成する

2. 実際にコードを確認し、以下の観点でレビューを行う
  - コードの正確性
  - パフォーマンス
  - セキュリティ
  - 可読性
  - 保守性
  - コーディング規約の遵守

3. 必要に応じて、具体的な改善点を指摘する

</details>

<!-- for GitHub Copilot review rule -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)