### PR TITLE
[fix] .claude/skills 配下スキルのフロントマター必須フィールドを補完

### DIFF
--- a/.claude/skills/plugin-integration-test/SKILL.md
+++ b/.claude/skills/plugin-integration-test/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: plugin-integration-test
 description: "sdd-workflow プラグインの統合テストを実行する。session-start.py、環境変数、/sdd-init を検証しログを記録する。"
+version: 1.0.0
+license: MIT
+argument-hint: "[none]"
 disable-model-invocation: true
 context: fork
 user-invocable: true

--- a/.claude/skills/plugin-lint/SKILL.md
+++ b/.claude/skills/plugin-lint/SKILL.md
@@ -4,6 +4,7 @@ description: "Lint check for AI-SDD plugin prompt files and support file structu
 version: 3.0.0
 license: MIT
 user-invocable: true
+argument-hint: "[none]"
 allowed-tools: Bash, Read
 ---
 

--- a/.claude/skills/review-plugin/SKILL.md
+++ b/.claude/skills/review-plugin/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: review-plugin
 description: "Claude Codeプラグインの品質レビュー。Agents, Skills, Hooks, プラグイン構造を設計ガイドに基づいてチェックし、改善提案を提供します。"
+version: 1.0.0
+license: MIT
+user-invocable: true
 argument-hint: "[対象パス|--agents|--skills|--hooks|--all]"
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Workflow


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

`.claude/skills/` 配下（リポジトリ開発用の内部skill）の一部で、`plugins/sdd-workflow/skills/` 配下の19スキルと比較してフロントマターの必須フィールドが欠落していたため、同水準に揃える。

## 変更内容

- `review-plugin/SKILL.md`: `version`, `license`, `user-invocable` を追加
- `plugin-integration-test/SKILL.md`: `version`, `license`, `argument-hint` を追加
- `plugin-lint/SKILL.md`: `argument-hint` を追加

## レビューの焦点

- `plugin-integration-test`, `plugin-lint` は引数を取らない自動実行スキルのため `argument-hint: "[none]"` としている点が適切か
- 追加した `version` の初期値（新規追加分は `1.0.0`）が既存の運用ルールと矛盾しないか

## テスト計画

- [x] `cat plugins/*/.claude-plugin/*.json | jq .` JSON構文チェック通過
- [x] `python3 .claude/skills/plugin-lint/scripts/plugin_lint.py` で lint 実行し問題なしを確認（今回の変更は `.claude/skills/` 配下でplugin-lintのスキャン対象外だが、既存の lint 結果に影響がないことを確認）
- [x] Markdownリンクの整合性確認（本PRではリンク変更なし）

## 参考資料

- Closes #66