### PR TITLE
[add] 分析・検出系スキルに disallowed-tools を追加し Vibe Coding 防止を構造的に強化

### DIFF
--- a/plugins/sdd-workflow/skills/analyze-requirements/SKILL.md
+++ b/plugins/sdd-workflow/skills/analyze-requirements/SKILL.md
@@ -7,6 +7,7 @@ user-invocable: true
 context: fork
 agent: sonnet
 allowed-tools: Read, Glob, Grep, AskUserQuestion
+disallowed-tools: Write, Edit, Bash
 ---
 
 # Analyze Requirements

--- a/plugins/sdd-workflow/skills/check-spec/SKILL.md
+++ b/plugins/sdd-workflow/skills/check-spec/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "[feature-name] [--full]"
 license: MIT
 user-invocable: true
 allowed-tools: Read, Glob, Grep, AskUserQuestion, Bash
+disallowed-tools: Write, Edit
 ---
 
 # Check Spec - Design & Implementation Consistency Check

--- a/plugins/sdd-workflow/skills/clarify/SKILL.md
+++ b/plugins/sdd-workflow/skills/clarify/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "<feature-name> [--interactive]"
 license: MIT
 user-invocable: true
 allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
+disallowed-tools: Bash
 ---
 
 # Clarify - Specification Clarification

--- a/plugins/sdd-workflow/skills/doc-consistency-checker/SKILL.md
+++ b/plugins/sdd-workflow/skills/doc-consistency-checker/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "[feature-name]"
 license: MIT
 user-invocable: false
 allowed-tools: Read, Glob, Grep
+disallowed-tools: Write, Edit, Bash
 ---
 
 # Doc Consistency Checker - Document Consistency Check

--- a/plugins/sdd-workflow/skills/finalize-prd/SKILL.md
+++ b/plugins/sdd-workflow/skills/finalize-prd/SKILL.md
@@ -7,6 +7,7 @@ user-invocable: true
 context: fork
 agent: sonnet
 allowed-tools: Read, Glob, Grep, AskUserQuestion
+disallowed-tools: Write, Edit, Bash
 ---
 
 # Finalize PRD

--- a/plugins/sdd-workflow/skills/generate-requirements-diagram/SKILL.md
+++ b/plugins/sdd-workflow/skills/generate-requirements-diagram/SKILL.md
@@ -7,6 +7,7 @@ user-invocable: true
 context: fork
 agent: sonnet
 allowed-tools: Read, Glob, Grep, AskUserQuestion
+disallowed-tools: Write, Edit, Bash
 ---
 
 # Generate Requirements Diagram

--- a/plugins/sdd-workflow/skills/generate-usecase-diagram/SKILL.md
+++ b/plugins/sdd-workflow/skills/generate-usecase-diagram/SKILL.md
@@ -7,6 +7,7 @@ user-invocable: true
 context: fork
 agent: sonnet
 allowed-tools: Read, Glob, Grep, AskUserQuestion
+disallowed-tools: Write, Edit, Bash
 ---
 
 # Generate Use Case Diagram

--- a/plugins/sdd-workflow/skills/vibe-detector/SKILL.md
+++ b/plugins/sdd-workflow/skills/vibe-detector/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "[user-instruction]"
 license: MIT
 user-invocable: false
 allowed-tools: Read, Glob, Grep, AskUserQuestion
+disallowed-tools: Write, Edit, Bash
 ---
 
 # Vibe Detector - Automatic Detection of Vague Instructions


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

Issue #79 の対応。分析・検出系スキルは従来 `allowed-tools`（許可プロンプト省略）のみで、スキル実行中の実装着手（Write / Edit / Bash）を構造的にブロックできていなかった。公式サポートされている Skill frontmatter の `disallowed-tools` を追加し、分析中の実装ツール使用を禁止する。

Closes #79

## 変更内容

各スキルの特性に応じて `disallowed-tools` を調整した（frontmatter のみの変更、計 8 ファイル 8 行追加）:

- [x] `vibe-detector` / `doc-consistency-checker` / `analyze-requirements` / `finalize-prd` / `generate-requirements-diagram` / `generate-usecase-diagram`: `disallowed-tools: Write, Edit, Bash`（読み取り専用の分析スキル）
- [x] `check-spec`: `disallowed-tools: Write, Edit`（Bash は実装コード確認に必要なため許可を維持）
- [x] `clarify`: `disallowed-tools: Bash`（Write / Edit は回答の仕様書反映に必要なため許可を維持）

## レビューの焦点

- `run-checklist` は Issue 本文で対象例に挙げられていたが、Write / Edit（チェックリスト更新）と Bash（テスト・リンター実行）がすべて本来機能に必須のため**対象外**とした。この判断の妥当性
- 各スキルの `allowed-tools` と `disallowed-tools` に重複・矛盾がないこと

## テスト計画

- [x] `cat plugins/*/.claude-plugin/*.json | jq .` JSON構文チェック通過
- [x] `bash scripts/plugin-lint.sh` および `plugin_lint.py` 通過（findings 0 件）
- [ ] 対象スキル実行中に禁止ツールの呼び出しがブロックされることの手動確認（`claude --plugin-dir ./plugins/sdd-workflow`）

## 参考資料

- Issue #79 / #68（調査元: docs/investigations/68-claude-code-feature-adoption.md）
- #57（lint の検証対象へ disallowed-tools を追加する件は別 Issue で対応）


<!-- for GitHub Copilot review rule -->

<details>
<summary>for GitHub Copilot review rule</summary>

## お願い

- 日本語で回答してください
- 簡潔で分かりやすい説明を心がけてください
- ベストプラクティスの具体例を提示してください
- 指摘の根拠となる情報源や学習リソースの提案を積極的に行ってください

## レビュールール

以下のプレフィックスを使用してレビューコメントを分類してください：

- `[must]` - 必須修正項目（セキュリティ、バグ、重大な設計問題）
- `[recommend]` - 推奨修正項目（パフォーマンス、可読性の大幅改善）
- `[nits]` - 軽微な指摘（コードスタイル、タイポ等）

## レビューステップ

1. コードの差分よりPRの概要を作成する

2. 実際にコードを確認し、以下の観点でレビューを行う
  - コードの正確性
  - パフォーマンス
  - セキュリティ
  - 可読性
  - 保守性
  - コーディング規約の遵守

3. 必要に応じて、具体的な改善点を指摘する

</details>

<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)