### PR TITLE
[update] PreToolUseフックのJSON Decision Control化とCONSTITUTION.md原則の動的注入

### DIFF
--- a/.claude/rules/repository-structure.md
+++ b/.claude/rules/repository-structure.md
@@ -54,7 +54,7 @@ ai-sdd-workflow/
 │       │   ├── session-start.py   # セッション開始時の初期化
 │       │   ├── hook_common.py     # フックスクリプト共通ヘルパー
 │       │   ├── user-prompt-submit.py  # Vibe Coding兆候検知
-│       │   ├── pre-tool-use.py    # .sdd/ ファイル命名規則検証
+│       │   ├── pre-tool-use.py    # .sdd/ ファイル命名規則検証・CONSTITUTION原則注入
 │       │   └── post-tool-use.py   # ドキュメント更新漏れ検知
 │       ├── AI-SDD-PRINCIPLES.source.md
 │       ├── LICENSE

--- a/plugins/sdd-workflow/CHANGELOG.ja.md
+++ b/plugins/sdd-workflow/CHANGELOG.ja.md
@@ -11,6 +11,17 @@
 
 ### Changed
 
+#### Hooks
+
+- **`PreToolUse`** (`scripts/pre-tool-use.py`) - 命名規則違反のブロックを stderr + `exit 2` 方式から
+  JSON Decision Control（`permissionDecision: "deny"` + `permissionDecisionReason`）へ移行
+  ([#82](https://github.com/ToshikiImagawa/ai-sdd-workflow/issues/82))
+- **`PreToolUse`** - Write/Edit 対象が実装コードの場合に `.sdd/CONSTITUTION.md` の原則を
+  `additionalContext` として注入 ([#82](https://github.com/ToshikiImagawa/ai-sdd-workflow/issues/82))
+    - コンテキスト肥大化を防ぐため、注入はプロジェクト内のソースファイル編集に限定し、
+      セッションごとに最大1回、3000文字で切り詰めて注入する
+    - CONSTITUTION.md が存在しない場合は何も注入しない
+
 #### Agents
 
 - **`front-matter-reviewer`** - `model` を `sonnet` から `haiku` に変更 ([#55](https://github.com/ToshikiImagawa/ai-sdd-workflow/issues/55))

--- a/plugins/sdd-workflow/CHANGELOG.md
+++ b/plugins/sdd-workflow/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### Hooks
+
+- **`PreToolUse`** (`scripts/pre-tool-use.py`) - Migrated naming-violation blocking from stderr + `exit 2`
+  to JSON Decision Control (`permissionDecision: "deny"` + `permissionDecisionReason`)
+  ([#82](https://github.com/ToshikiImagawa/ai-sdd-workflow/issues/82))
+- **`PreToolUse`** - Injects `.sdd/CONSTITUTION.md` principles as `additionalContext` when Write/Edit
+  targets implementation source code ([#82](https://github.com/ToshikiImagawa/ai-sdd-workflow/issues/82))
+    - Injection is limited to source-file edits inside the project, happens at most once per session,
+      and is truncated to 3000 characters to avoid context bloat
+    - Nothing is injected when CONSTITUTION.md does not exist
+
 #### Agents
 
 - **`front-matter-reviewer`** - Changed `model` from `sonnet` to `haiku` ([#55](https://github.com/ToshikiImagawa/ai-sdd-workflow/issues/55))

--- a/plugins/sdd-workflow/README.md
+++ b/plugins/sdd-workflow/README.md
@@ -146,7 +146,7 @@ This command automatically:
 |:----------------|:-------------|:------------------------------------------------------------------------------------|
 | `session-start` | SessionStart | Loads settings from `.sdd-config.json` and sets environment variables automatically |
 | `user-prompt-submit` | UserPromptSubmit | Detects Vibe Coding signals (vague instructions) in the user prompt and injects a clarification reminder |
-| `pre-tool-use`  | PreToolUse (Write/Edit) | Blocks writes to `.sdd/` documents that violate file naming conventions |
+| `pre-tool-use`  | PreToolUse (Write/Edit) | Denies writes to `.sdd/` documents that violate file naming conventions, and injects `CONSTITUTION.md` principles when editing implementation source code (once per session) |
 | `post-tool-use` | PostToolUse (Write/Edit) | Reminds about document consistency checks after editing `.sdd/` docs or source files with a matching design doc |
 
 **Note**: Hooks are automatically enabled when the plugin is installed. No additional configuration is required.
@@ -359,7 +359,7 @@ This plugin automatically loads `.sdd-config.json` and sets environment variable
 |:----------------|:-------------|:----------------------------------------------------------------------|
 | `session-start` | SessionStart | Loads settings from `.sdd-config.json` and sets environment variables |
 | `user-prompt-submit` | UserPromptSubmit | Detects Vibe Coding signals (vague instructions) in the user prompt and injects a clarification reminder |
-| `pre-tool-use`  | PreToolUse (Write/Edit) | Blocks writes to `.sdd/` documents that violate file naming conventions |
+| `pre-tool-use`  | PreToolUse (Write/Edit) | Denies writes to `.sdd/` documents that violate file naming conventions, and injects `CONSTITUTION.md` principles when editing implementation source code (once per session) |
 | `post-tool-use` | PostToolUse (Write/Edit) | Reminds about document consistency checks after editing `.sdd/` docs or source files with a matching design doc |
 
 ### Environment Variables Set

--- a/plugins/sdd-workflow/scripts/hook_common.py
+++ b/plugins/sdd-workflow/scripts/hook_common.py
@@ -50,6 +50,22 @@ def load_sdd_paths(project_root: str) -> Tuple[str, str, str]:
     return root, requirement_dir, specification_dir
 
 
+SOURCE_EXTENSIONS = (
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java",
+    ".kt", ".swift", ".cs", ".rb", ".php", ".c", ".cc", ".cpp", ".h",
+)
+
+
+def emit_permission_deny(event_name: str, reason: str) -> None:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        },
+    }, ensure_ascii=False))
+
+
 def emit_additional_context(event_name: str, text: str) -> None:
     print(json.dumps({
         "hookSpecificOutput": {

--- a/plugins/sdd-workflow/scripts/post-tool-use.py
+++ b/plugins/sdd-workflow/scripts/post-tool-use.py
@@ -11,16 +11,12 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_common import (  # noqa: E402
+    SOURCE_EXTENSIONS,
     emit_additional_context,
     get_project_root,
     load_sdd_paths,
     read_stdin_json,
     relative_to_project,
-)
-
-SOURCE_EXTENSIONS = (
-    ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java",
-    ".kt", ".swift", ".cs", ".rb", ".php", ".c", ".cc", ".cpp", ".h",
 )
 
 

--- a/plugins/sdd-workflow/scripts/pre-tool-use.py
+++ b/plugins/sdd-workflow/scripts/pre-tool-use.py
@@ -5,19 +5,33 @@ Validates AI-SDD file naming conventions before writing to .sdd/ documents:
 - requirement/: no _spec/_design suffix allowed
 - specification/: _spec.md or _design.md suffix required
 
-Blocks the tool call (exit 2) on violation.
+Blocks the tool call via JSON Decision Control (permissionDecision: "deny")
+on violation.
+
+When the write target is implementation source code, injects the project's
+CONSTITUTION.md principles as additionalContext. To avoid context bloat:
+- only source files inside the project are targeted
+- injection happens at most once per session (marker file keyed by session_id)
+- the injected text is truncated to CONSTITUTION_MAX_CHARS
 """
 
 import os
+import re
 import sys
+import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_common import (  # noqa: E402
+    SOURCE_EXTENSIONS,
+    emit_additional_context,
+    emit_permission_deny,
     get_project_root,
     load_sdd_paths,
     read_stdin_json,
     relative_to_project,
 )
+
+CONSTITUTION_MAX_CHARS = 3000
 
 
 def validate_naming(rel_path: str, requirement_prefix: str, specification_prefix: str) -> str:
@@ -43,6 +57,56 @@ def validate_naming(rel_path: str, requirement_prefix: str, specification_prefix
     return ""
 
 
+def session_marker_path(session_id: str) -> str:
+    safe_id = re.sub(r"[^A-Za-z0-9_-]", "_", session_id)
+    return os.path.join(tempfile.gettempdir(), f"sdd-constitution-injected-{safe_id}")
+
+
+def load_constitution(project_root: str, sdd_root: str) -> str:
+    """Return the CONSTITUTION.md content (truncated), or '' if absent."""
+    path = os.path.join(project_root, sdd_root, "CONSTITUTION.md")
+    if not os.path.isfile(path):
+        return ""
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read().strip()
+    except OSError:
+        return ""
+    if len(text) > CONSTITUTION_MAX_CHARS:
+        text = text[:CONSTITUTION_MAX_CHARS] + "\n... (truncated; see the full file)"
+    return text
+
+
+def maybe_inject_constitution(rel_path: str, project_root: str, sdd_root: str, session_id: str) -> None:
+    _stem, ext = os.path.splitext(rel_path)
+    if ext not in SOURCE_EXTENSIONS:
+        return
+
+    marker = ""
+    if session_id:
+        marker = session_marker_path(session_id)
+        if os.path.exists(marker):
+            return
+
+    text = load_constitution(project_root, sdd_root)
+    if not text:
+        return
+
+    if marker:
+        try:
+            with open(marker, "w", encoding="utf-8") as f:
+                f.write(rel_path)
+        except OSError:
+            pass
+
+    constitution_rel = os.path.join(sdd_root, "CONSTITUTION.md")
+    emit_additional_context(
+        "PreToolUse",
+        f"[AI-SDD] You are editing implementation code ('{rel_path}'). "
+        f"Follow the project principles defined in '{constitution_rel}':\n\n{text}",
+    )
+
+
 def main() -> None:
     payload = read_stdin_json()
     file_path = payload.get("tool_input", {}).get("file_path", "")
@@ -60,8 +124,11 @@ def main() -> None:
 
     error = validate_naming(rel_path, requirement_prefix, specification_prefix)
     if error:
-        print(error, file=sys.stderr)
-        sys.exit(2)
+        emit_permission_deny("PreToolUse", error)
+        return
+
+    if not rel_path.startswith(sdd_root + os.sep):
+        maybe_inject_constitution(rel_path, project_root, sdd_root, payload.get("session_id", ""))
 
 
 if __name__ == "__main__":

--- a/scripts/test-hook-scripts.sh
+++ b/scripts/test-hook-scripts.sh
@@ -87,13 +87,17 @@ run_hook "pre: valid spec name passes" "pre-tool-use.py" \
     "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/specification/user-login_spec.md\"}}" \
     0 ""
 
-run_hook "pre: specification without suffix is blocked" "pre-tool-use.py" \
+run_hook "pre: specification without suffix is denied via JSON" "pre-tool-use.py" \
     "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/specification/user-login.md\"}}" \
-    2 "Naming violation"
+    0 "\"permissionDecision\": \"deny\""
 
-run_hook "pre: requirement with _spec suffix is blocked" "pre-tool-use.py" \
+run_hook "pre: deny reason mentions the naming violation" "pre-tool-use.py" \
+    "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/specification/user-login.md\"}}" \
+    0 "Naming violation"
+
+run_hook "pre: requirement with _spec suffix is denied via JSON" "pre-tool-use.py" \
     "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/requirement/user-login_spec.md\"}}" \
-    2 "Naming violation"
+    0 "\"permissionDecision\": \"deny\""
 
 run_hook "pre: requirement without suffix passes" "pre-tool-use.py" \
     "{\"cwd\": \"$TMP_DIR\", \"tool_input\": {\"file_path\": \"$TMP_DIR/.sdd/requirement/user-login.md\"}}" \
@@ -106,6 +110,27 @@ run_hook "pre: non-sdd file passes" "pre-tool-use.py" \
 run_hook "pre: invalid stdin is a no-op" "pre-tool-use.py" \
     "not-json" \
     0 ""
+
+# Constitution injection tests (separate project with .sdd/CONSTITUTION.md)
+CONST_DIR="$TMP_DIR/const-project"
+mkdir -p "$CONST_DIR/.sdd" "$CONST_DIR/src"
+printf '# Project Constitution\n\n- Simplicity first\n' > "$CONST_DIR/.sdd/CONSTITUTION.md"
+SESSION_ID="test-hook-$$"
+rm -f "${TMPDIR:-/tmp}/sdd-constitution-injected-${SESSION_ID}"
+
+run_hook "pre: source edit injects CONSTITUTION principles" "pre-tool-use.py" \
+    "{\"cwd\": \"$CONST_DIR\", \"session_id\": \"$SESSION_ID\", \"tool_input\": {\"file_path\": \"$CONST_DIR/src/main.py\"}}" \
+    0 "Simplicity first"
+
+run_hook "pre: second injection in same session is suppressed" "pre-tool-use.py" \
+    "{\"cwd\": \"$CONST_DIR\", \"session_id\": \"$SESSION_ID\", \"tool_input\": {\"file_path\": \"$CONST_DIR/src/other.py\"}}" \
+    0 ""
+
+run_hook "pre: non-source file gets no injection" "pre-tool-use.py" \
+    "{\"cwd\": \"$CONST_DIR\", \"session_id\": \"$SESSION_ID-doc\", \"tool_input\": {\"file_path\": \"$CONST_DIR/README.md\"}}" \
+    0 ""
+
+rm -f "${TMPDIR:-/tmp}/sdd-constitution-injected-${SESSION_ID}"
 
 echo "=== post-tool-use.py ==="
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

PreToolUse フックを stderr + `exit 2` の旧方式から公式サポートの JSON Decision Control 方式へ移行し、実装コード編集時に CONSTITUTION.md の原則を `additionalContext` として動的注入する仕組みを追加します。#68 の調査（docs/investigations/68-claude-code-feature-adoption.md）で確認した公式仕様に基づく対応です。

Closes #82

## 変更内容

- [x] `scripts/pre-tool-use.py`: 命名規則違反ブロックを `permissionDecision: "deny"` + `permissionDecisionReason` の JSON 出力（exit 0）へ移行
- [x] `scripts/pre-tool-use.py`: Write/Edit 対象がプロジェクト内の実装コード（ソース拡張子）の場合に `.sdd/CONSTITUTION.md` を `additionalContext` として注入
  - コンテキスト肥大化対策（#25 と同根）: 対象パス判定（ソースファイルのみ）／session_id ベースのマーカーファイルでセッションごと最大1回／3000文字で切り詰め
  - CONSTITUTION.md 不在時は何も注入しない
- [x] `scripts/hook_common.py`: `emit_permission_deny()` ヘルパーと `SOURCE_EXTENSIONS` を追加（post-tool-use.py と共通化）
- [x] `scripts/test-hook-scripts.sh`: deny JSON 検証・CONSTITUTION 注入（初回注入／同一セッション抑制／非ソースファイル除外）の回帰テストを追加
- [x] CHANGELOG（en/ja）・README・`.claude/rules/repository-structure.md` を更新

## レビューの焦点

- `plugins/sdd-workflow/scripts/pre-tool-use.py` の注入条件設計（`maybe_inject_constitution`）: セッション単位の抑制に `tempfile.gettempdir()` 配下のマーカーファイルを使用している点
- deny 時は注入を行わず、`.sdd/` 配下のファイルは注入対象外としている分岐

## テスト計画

- [x] `cat plugins/*/.claude-plugin/*.json | jq .` JSON構文チェック通過
- [x] `sh scripts/test-hook-scripts.sh` 17 passed（新規テスト5件含む）
- [x] `sh scripts/plugin-lint.sh` / `sh scripts/test-session-start.sh` / `python3 -m pytest tests/` 通過
- [x] `shellcheck -S warning -e SC1091 scripts/*.sh` 通過
- [ ] `claude --plugin-dir ./plugins/sdd-workflow` でローカル動作確認（手動）

## 参考資料

- #82 / #68（調査元）/ #25（コンテキスト最適化）/ #54（hooks 基盤）
- docs/investigations/68-claude-code-feature-adoption.md
- https://code.claude.com/docs/en/hooks.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- for GitHub Copilot review rule -->

<details>
<summary>for GitHub Copilot review rule</summary>

## お願い

- 日本語で回答してください
- 簡潔で分かりやすい説明を心がけてください
- ベストプラクティスの具体例を提示してください
- 指摘の根拠となる情報源や学習リソースの提案を積極的に行ってください

## レビュールール

以下のプレフィックスを使用してレビューコメントを分類してください：

- `[must]` - 必須修正項目（セキュリティ、バグ、重大な設計問題）
- `[recommend]` - 推奨修正項目（パフォーマンス、可読性の大幅改善）
- `[nits]` - 軽微な指摘（コードスタイル、タイポ等）

## レビューステップ

1. コードの差分よりPRの概要を作成する

2. 実際にコードを確認し、以下の観点でレビューを行う
  - コードの正確性
  - パフォーマンス
  - セキュリティ
  - 可読性
  - 保守性
  - コーディング規約の遵守

3. 必要に応じて、具体的な改善点を指摘する

</details>

<!-- for GitHub Copilot review rule -->