### PR TITLE
[fix] Issue #48-68 一括レビューで検出したスキル参照切れ・フック定義・構成ドキュメントを修正

### DIFF
--- a/.claude/rules/repository-structure.md
+++ b/.claude/rules/repository-structure.md
@@ -12,7 +12,11 @@ ai-sdd-workflow/
 │       │   ├── spec-reviewer.md   # 仕様書レビューエージェント
 │       │   ├── prd-reviewer.md    # PRDレビューエージェント
 │       │   ├── requirement-analyzer.md  # 要求仕様分析エージェント
-│       │   └── clarification-assistant.md  # 仕様明確化アシスタント
+│       │   ├── clarification-assistant.md  # 仕様明確化アシスタント
+│       │   ├── front-matter-reviewer.md  # front matter検証エージェント
+│       │   ├── examples/          # エージェント利用例
+│       │   ├── references/        # エージェント参照資料
+│       │   └── templates/{en,ja}/ # エージェント出力テンプレート
 │       ├── skills/                # 19スキル
 │       │   ├── analyze-requirements/       # 要求分析（UR/FR/NFR抽出）
 │       │   ├── check-spec/                 # 実装とdesignの整合性チェック
@@ -44,6 +48,7 @@ ai-sdd-workflow/
 │       │   ├── sdd-init/                   # AI-SDDワークフロー初期化
 │       │   │   └── templates/{en,ja}/
 │       │   ├── task-breakdown/             # タスク分解
+│       │   │   └── templates/{en,ja}/
 │       │   ├── task-cleanup/               # タスククリーンアップ
 │       │   │   └── templates/{en,ja}/
 │       │   └── vibe-detector/              # Vibe Coding検出

--- a/plugins/sdd-workflow/hooks/hooks.json
+++ b/plugins/sdd-workflow/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CLAUDE_PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT} python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py --default-lang en"
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py --default-lang en"
           }
         ]
       }
@@ -22,7 +22,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit",
+        "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "command",
@@ -33,7 +33,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit",
+        "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "command",

--- a/plugins/sdd-workflow/skills/finalize-prd/SKILL.md
+++ b/plugins/sdd-workflow/skills/finalize-prd/SKILL.md
@@ -39,7 +39,7 @@ This skill operates in two modes:
 
 | File                                                    | Purpose                                  |
 |:--------------------------------------------------------|:-----------------------------------------|
-| `../shared/references/prerequisites_directory_paths.md` | Resolve `${SDD_*}` environment variables |
+| `references/prerequisites_directory_paths.md`           | Resolve `${SDD_*}` environment variables |
 
 **Load PRD template** (in order):
 

--- a/plugins/sdd-workflow/skills/finalize-prd/references/prerequisites_directory_paths.md
+++ b/plugins/sdd-workflow/skills/finalize-prd/references/prerequisites_directory_paths.md
@@ -1,0 +1,1 @@
+../../../shared/references/prerequisites_directory_paths.md

--- a/plugins/sdd-workflow/skills/generate-prd/SKILL.md
+++ b/plugins/sdd-workflow/skills/generate-prd/SKILL.md
@@ -75,10 +75,10 @@ Read the following files from `$GENERATE_PRD_REFERENCES`:
 | `prerequisites_directory_paths.md`    | Resolve `${SDD_*}` environment variables |
 | `prerequisites_principles.md`         | Load AI-SDD principles                   |
 | `prerequisites_plugin_update.md`      | Check plugin version compatibility       |
-| `../../../shared/references/usecase_diagram_guide.md` | Use case diagram notation |
-| `../../../shared/references/mermaid_notation_rules.md` | Mermaid syntax rules |
-| `../../../shared/references/requirements_diagram_components.md` | SysML requirements diagram components |
-| `../../../shared/references/front_matter_prd.md` | PRD front matter schema |
+| `usecase_diagram_guide.md`            | Use case diagram notation                |
+| `mermaid_notation_rules.md`           | Mermaid syntax rules                     |
+| `requirements_diagram_components.md`  | SysML requirements diagram components    |
+| `front_matter_prd.md`                 | PRD front matter schema                  |
 
 **Load PRD template** from `$GENERATE_PRD_TEMPLATE`
 

--- a/plugins/sdd-workflow/skills/generate-prd/references/front_matter_prd.md
+++ b/plugins/sdd-workflow/skills/generate-prd/references/front_matter_prd.md
@@ -1,0 +1,1 @@
+../../../shared/references/front_matter_prd.md

--- a/plugins/sdd-workflow/skills/generate-prd/references/mermaid_notation_rules.md
+++ b/plugins/sdd-workflow/skills/generate-prd/references/mermaid_notation_rules.md
@@ -1,0 +1,1 @@
+../../../shared/references/mermaid_notation_rules.md

--- a/plugins/sdd-workflow/skills/generate-prd/references/requirements_diagram_components.md
+++ b/plugins/sdd-workflow/skills/generate-prd/references/requirements_diagram_components.md
@@ -1,0 +1,1 @@
+../../../shared/references/requirements_diagram_components.md

--- a/plugins/sdd-workflow/skills/generate-prd/references/usecase_diagram_guide.md
+++ b/plugins/sdd-workflow/skills/generate-prd/references/usecase_diagram_guide.md
@@ -1,0 +1,1 @@
+../../../shared/references/usecase_diagram_guide.md


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

Issue #48〜#68 の並列実装（PR #70〜#91）の一括レビューで検出した問題を修正します。主目的は、PR #86 のコードブロック分離後に壊れていた generate-prd / finalize-prd の shared/references 参照の修復です。

## 変更内容

- [x] `skills/generate-prd/references/` に shared/references 4ファイル（usecase_diagram_guide 等）への symlink を追加し、SKILL.md の参照を既存パターン（`$GENERATE_PRD_REFERENCES` 経由）に統一
- [x] `skills/finalize-prd/references/` に `prerequisites_directory_paths.md` の symlink を追加し、SKILL.md の壊れた相対パス `../shared/...` を `references/...` に修正
- [x] `hooks.json` から現行 Claude Code に存在しない `MultiEdit` matcher と、SessionStart コマンドの冗長な `CLAUDE_PLUGIN_ROOT=` 代入を削除
- [x] `.claude/rules/repository-structure.md` に front-matter-reviewer.md、agents 配下の examples/references/templates、task-breakdown の templates/{en,ja}/ を補完

## レビューの焦点

- symlink 方式の採用: `${CLAUDE_PLUGIN_ROOT}` 直接参照ではなく、他スキル（task-breakdown 等）と同じ「references/ に symlink + prepare スクリプトでキャッシュコピー」パターンに合わせました。`prepare-prd.py` の `copytree` は symlink の内容を実体コピーします
- `MultiEdit` 削除の妥当性（matcher にマッチしないだけで実害はなかったが不要のため削除）

## テスト計画

- [x] `cat plugins/*/.claude-plugin/*.json | jq .` JSON構文チェック通過
- [x] `bash scripts/plugin-lint.sh` / `validate-marketplace.sh` / `test-hook-scripts.sh` / `test-session-start.sh` 全パス
- [x] `python3 -m pytest tests/ -v` 42件パス
- [x] symlink 5件の解決確認
- [ ] `claude --plugin-dir ./plugins/sdd-workflow` でローカルテスト確認

## 参考資料

- Issue #48〜#68 一括レビュー（レビュー指示: `.claude/worktrees/review-session-prompt.md`）
- 関連 PR: #86（コードブロック分離）、#77（フック追加）、#91（構成ドキュメント修正）

<!-- for GitHub Copilot review rule -->

<details>
<summary>for GitHub Copilot review rule</summary>

## お願い

- 日本語で回答してください
- 簡潔で分かりやすい説明を心がけてください
- ベストプラクティスの具体例を提示してください
- 指摘の根拠となる情報源や学習リソースの提案を積極的に行ってください

## レビュールール

以下のプレフィックスを使用してレビューコメントを分類してください：

- `[must]` - 必須修正項目（セキュリティ、バグ、重大な設計問題）
- `[recommend]` - 推奨修正項目（パフォーマンス、可読性の大幅改善）
- `[nits]` - 軽微な指摘（コードスタイル、タイポ等）

## レビューステップ

1. コードの差分よりPRの概要を作成する

2. 実際にコードを確認し、以下の観点でレビューを行う
  - コードの正確性
  - パフォーマンス
  - セキュリティ
  - 可読性
  - 保守性
  - コーディング規約の遵守

3. 必要に応じて、具体的な改善点を指摘する

</details>

<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)