### PR TITLE
[fix] 6 PRD の横断レビュー指摘を修正し要求図の記法規約を明文化

### DIFF
--- a/.claude/rules/sdd-front-matter.md
+++ b/.claude/rules/sdd-front-matter.md
@@ -24,4 +24,6 @@ prd ← spec (depends-on: prd) ← design (depends-on: spec) ← task (depends-o
 ```
 
 - 階層構造の場合: `id` にパスを含める（例: `"spec-auth-user-login"`）
+- feature 名自体が type プレフィックスで始まる場合（例: feature 名 `prd-generation`）は、二重接頭辞
+  （`"prd-prd-generation"`）とせず feature 名をそのまま `id` とする（例: `"prd-generation"`）
 - front matterなしの既存ドキュメントも引き続き有効（後方互換）

--- a/.sdd/PRD_TEMPLATE.md
+++ b/.sdd/PRD_TEMPLATE.md
@@ -51,6 +51,15 @@ SysML 要求図の記法（要求タイプ・リスクレベル・検証方法�
 | 検証方法   | `Analysis`（分析） / `Test`（テスト） / `Demonstration`（デモ） / `Inspection`（レビュー）                         |
 | 関係タイプ  | `contains`（包含） / `derives`（派生） / `satisfies`（満足） / `verifies`（検証） / `refines`（詳細化） / `traces`（トレース） |
 
+**本プロジェクトの記法規約**（レビュー時の解釈ブレを防ぐための統一ルール）:
+
+- 機能要求からユーザー要求への派生は `FR - derives -> UR` の方向で記載する
+- 制約・非機能要求（NFR / IR / DC）から対象要求への関連は `制約 - traces -> 要求` の方向で記載する
+  （制約を起点として「どの要求に効くか」を示す本プロジェクトの統一方向。SysML の厳密な traces 意味論より一貫性を優先する）
+- 非機能要求の ID プレフィックスは `NFR` に統一する（要求タイプは内容に応じて `requirement` / `performanceRequirement` 等を選択してよい）
+- Mermaid requirementDiagram に `nonfunctionalRequirement` タイプは存在しないため使用しない
+- 要求 ID（`UR_001` 等）のスコープは各 PRD ファイル内とする。PRD をまたいで参照する場合はファイル名と ID を併記する
+
 ---
 
 # 2. 要求一覧 `<MUST>`

--- a/.sdd/requirement/distribution.md
+++ b/.sdd/requirement/distribution.md
@@ -209,6 +209,7 @@ requirementDiagram
     NoCodeBlockInPrompt - traces -> CiValidation
     TemplateSetParity - traces -> I18nTemplates
     TemplateSetParity - traces -> BilingualParity
+    CrossPlatform - traces -> CiValidation
 ```
 
 ## 3.2. 主要サブシステム詳細図
@@ -389,6 +390,8 @@ marketplace.json / plugin.json は Claude Code のマーケットプレイス・
 
 - B-002 原則（多言語対応の一貫性）に従い、EN/JA の機能差を生む変更は認めない
 - T-002 原則（plugin.json 登録の徹底）に従い、新規スキル・エージェント追加時はマニフェスト登録を必須とする
+- T-003 原則（日本語出力の文字化け防止）に従い、ja テンプレート・日本語ドキュメントに文字化け
+  （U+FFFD・mojibake パターン・不完全なマルチバイト文字）を混入させないこと
 
 ---
 

--- a/.sdd/requirement/quality-guardrails.md
+++ b/.sdd/requirement/quality-guardrails.md
@@ -4,7 +4,7 @@ title: "品質ガードレール"
 type: "prd"
 status: "draft"
 created: "2026-07-06"
-updated: "2026-07-06"
+updated: "2026-07-07"
 depends-on: []
 tags: ["vibe-coding-prevention", "hooks", "consistency-check", "quality-gate"]
 category: "quality-guardrails"
@@ -76,7 +76,6 @@ flowchart LR
     HookRuntime -.->|"イベント発火"| EnforceNaming
     HookRuntime -.->|"イベント発火"| InjectPrinciples
     HookRuntime -.->|"イベント発火"| DetectStale
-    DetectVibe -.->|"<<包含>>"| CheckDocs
 ```
 
 ## 2.2. ユースケース図（詳細）
@@ -225,7 +224,7 @@ requirementDiagram
     }
 
     performanceRequirement HookLightweight {
-        id: PR_001
+        id: NFR_001
         text: "フック処理は軽量でプロンプト応答性を阻害しない"
         risk: medium
         verifymethod: test
@@ -269,18 +268,21 @@ requirementDiagram
     QualityGuardrails - contains -> AmbiguityPrevention
     QualityGuardrails - contains -> ConsistencyAssurance
     QualityGuardrails - contains -> PrincipleCompliance
-    AmbiguityPrevention - contains -> VibeDetection
-    PrincipleCompliance - contains -> NamingEnforcement
-    PrincipleCompliance - contains -> ConstitutionInjection
-    ConsistencyAssurance - contains -> StaleDocDetection
-    ConsistencyAssurance - contains -> ImplSpecCheck
-    ConsistencyAssurance - contains -> DocConsistencyCheck
-    ConsistencyAssurance - contains -> FrontMatterValidation
+    VibeDetection - derives -> AmbiguityPrevention
+    NamingEnforcement - derives -> PrincipleCompliance
+    ConstitutionInjection - derives -> PrincipleCompliance
+    StaleDocDetection - derives -> ConsistencyAssurance
+    ImplSpecCheck - derives -> ConsistencyAssurance
+    DocConsistencyCheck - derives -> ConsistencyAssurance
+    FrontMatterValidation - derives -> ConsistencyAssurance
     VibeDetection - traces -> HookEventCompliance
     NamingEnforcement - traces -> HookEventCompliance
     StaleDocDetection - traces -> HookEventCompliance
     ConstitutionInjection - traces -> HookEventCompliance
     HookLightweight - traces -> VibeDetection
+    HookLightweight - traces -> NamingEnforcement
+    HookLightweight - traces -> ConstitutionInjection
+    HookLightweight - traces -> StaleDocDetection
     MinimalBlocking - traces -> NamingEnforcement
     ContextBudget - traces -> ConstitutionInjection
     CostOptimization - traces -> FrontMatterValidation
@@ -367,6 +369,8 @@ CONSTITUTION.md に定義されたプロジェクト原則が、AI 実装者の�
 
 ユーザープロンプト送信時に曖昧表現を検知し、明確化を促す。UR_002 から派生。
 
+**トリガー方式:** 自動（プロンプト送信イベントのフック、および実装前の自動実行スキル）
+
 **含まれる機能:**
 
 - FR_001_01: 日英の曖昧表現パターン検知（例:「いい感じ」「よしなに」「なんとなく」「make it nice」「somehow」）
@@ -379,6 +383,8 @@ CONSTITUTION.md に定義されたプロジェクト原則が、AI 実装者の�
 
 `.sdd/` 配下へのファイル書き込み・編集時に命名規則を検証し、違反時は書き込みをブロックする。UR_004 から派生。
 
+**トリガー方式:** 自動（`.sdd/` 配下へのファイル書き込み・編集前のフック）
+
 - `requirement/` 配下: `_spec` / `_design` サフィックスの付与を禁止
 - `specification/` 配下: `_spec.md` または `_design.md` サフィックスを必須とする
 - 違反時は JSON Decision Control（`permissionDecision: deny`）により理由付きでブロックする
@@ -390,11 +396,15 @@ CONSTITUTION.md に定義されたプロジェクト原則が、AI 実装者の�
 実装ソースコードの編集時に、プロジェクトの CONSTITUTION.md の内容を追加コンテキストとして AI 実装者に注入する。
 UR_004 から派生。CONSTITUTION.md が存在しない場合は何もしない。
 
+**トリガー方式:** 自動（実装ソースコード編集前のフック）
+
 **検証方法:** テストによる検証
 
 ### FR_004: ドキュメント更新漏れ検知
 
 ファイル編集後に更新漏れの可能性を検知し、確認を促す。UR_003 から派生。
+
+**トリガー方式:** 自動（ファイル編集後のフック）
 
 - `.sdd/` ドキュメント編集後: PRD ↔ spec ↔ design の整合性確認を促す
 - ソースコード編集時: 対応する `{stem}_design.md` が存在する場合、設計書の同期を促す
@@ -427,11 +437,13 @@ PRD ↔ `*_spec.md` ↔ `*_design.md` 間の以下の不整合を検出する。
 AI-SDD ドキュメントの YAML front matter に対し、フィールド形式・値の妥当性・依存方向
 （`depends-on` は上流方向のみ）・ID 一意性を検証する。UR_003 から派生。
 
+**トリガー方式:** 自動（ドキュメント生成後・整合性チェック時のレビューとして実行）。手動呼び出しも可
+
 **検証方法:** テストによる検証
 
-## 4.3. パフォーマンス要求
+## 4.3. 非機能要求
 
-### PR_001: フック処理の軽量性
+### NFR_001: フック処理の軽量性
 
 フック処理（曖昧性検知・命名検証・原則注入・更新漏れ検知）は軽量に実装し、
 プロンプト送信やファイル編集の応答性を阻害しないこと。
@@ -529,7 +541,7 @@ macOS / Linux の両方で動作し、`SDD_LANG` 環境変数による日英の�
 
 | 用語                    | 定義                                                                       |
 |-----------------------|--------------------------------------------------------------------------|
-| Vibe Coding           | 曖昧な指示により AI が未定義の要求を推測して実装してしまう問題                                        |
+| Vibe Coding           | 曖昧な指示により AI が仕様を暗黙的に推測して実装してしまう問題（CONSTITUTION.md B-001 の定義に従う）        |
 | 品質ゲート                 | 開発ワークフローの特定タイミングで自動実行される検証・警告・ブロック処理                                     |
 | フック                   | Claude Code のイベント（SessionStart / UserPromptSubmit / PreToolUse / PostToolUse）に応じて実行されるスクリプト |
 | JSON Decision Control | フックがツール実行の許可・拒否を JSON 出力（`permissionDecision`）で制御する Claude Code の仕組み      |

--- a/.sdd/requirement/spec-design.md
+++ b/.sdd/requirement/spec-design.md
@@ -208,6 +208,7 @@ requirementDiagram
     RefactorPlanning - traces -> NamingTemplateCompliance
     AbstractionSeparation - traces -> SpecGeneration
     LanguageConsistency - traces -> SpecGeneration
+    LanguageConsistency - traces -> RefactorPlanning
     Clarification - traces -> ClarityThreshold
 ```
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

`.sdd/requirement/` 配下の全 6 PRD（#97〜#102 で追加）に対して requirement-analyzer と横断整合レビューを実施し、検出された指摘のうち妥当なものをすべて修正しました。あわせて、レビューのたびに解釈が割れていた要求図の記法（derives/traces の方向、NFR の ID 体系、id の二重プレフィックス問題）を PRD_TEMPLATE.md と .claude/rules/sdd-front-matter.md に規約として明文化し、再発を防ぎます。

## 変更内容

- [x] **quality-guardrails.md**
  - ユースケース図の誤った包含関係（Vibe 検知 → ドキュメント整合性チェック）を削除
  - 「UR contains FR」を「FR derives UR」に統一（#98 以降の 5 PRD とスタイルを揃える）
  - PR_001 → NFR_001 に改名し「4.3 パフォーマンス要求」→「4.3 非機能要求」に統一
  - NFR_001（フック軽量性）の traces を全フック機能（命名強制・原則注入・更新漏れ検知）に拡充
  - FR_001〜FR_004・FR_007 にトリガー方式を明記（他 PRD の書式と統一）
  - 用語集の Vibe Coding 定義を CONSTITUTION.md B-001 の表現に整合
- [x] **spec-design.md**: DC_002（言語一貫性）の traces に RefactorPlanning を追加（本文の対象範囲と図を一致）
- [x] **distribution.md**: NFR_001（クロスプラットフォーム）の traces に CiValidation を追加、T-003 原則（文字化け防止）を 5.2 に追記
- [x] **PRD_TEMPLATE.md**: 記法規約を明文化（FR - derives -> UR 方向 / 制約 - traces -> 要求 方向 / NFR ID 統一 / nonfunctionalRequirement 禁止 / 要求 ID のファイル内スコープ）
- [x] **.claude/rules/sdd-front-matter.md**: feature 名が type プレフィックスで始まる場合の id 規則（二重接頭辞を避ける）を明文化 — prd-generation.md の id "prd-generation" を正とする

## レビューの焦点

- **記法規約の妥当性**: 「制約 - traces -> 要求」方向は SysML の厳密な意味論と異なりますが、既存 6 PRD すべてがこの方向で一貫しているため、書き換えではなく規約化を選択しました
- **不採用とした指摘**: depends-on の空配列（PRD の depends-on は親 PRD のみが仕様のため空が正しい）、front matter「検証」（quality-guardrails）と「推奨」（workflow-foundation）の責務重複（別責務でありスコープ外セクションで境界明示済み）

## テスト計画

- [x] Mermaid 要求図の未定義ノード参照・無効タイプなし（PR_001 リネームの残骸なしを grep で確認）
- [x] pre-tool-use フックの命名規則検証を通過
- [x] `.claude/rules/` の paths frontmatter を維持

## 参考資料

- #97〜#102 — 対象 PRD を追加した PR シリーズ
- [.sdd/CONSTITUTION.md](https://github.com/ToshikiImagawa/ai-sdd-workflow/blob/main/.sdd/CONSTITUTION.md) — B-001 / T-003


<!-- for GitHub Copilot review rule -->

<details>
<summary>for GitHub Copilot review rule</summary>

## お願い

- 日本語で回答してください
- 簡潔で分かりやすい説明を心がけてください
- ベストプラクティスの具体例を提示してください
- 指摘の根拠となる情報源や学習リソースの提案を積極的に行ってください

## レビュールール

以下のプレフィックスを使用してレビューコメントを分類してください：

- `[must]` - 必須修正項目（セキュリティ、バグ、重大な設計問題）
- `[recommend]` - 推奨修正項目（パフォーマンス、可読性の大幅改善）
- `[nits]` - 軽微な指摘（コードスタイル、タイポ等）

## レビューステップ

1. コードの差分よりPRの概要を作成する

2. 実際にコードを確認し、以下の観点でレビューを行う
  - コードの正確性
  - パフォーマンス
  - セキュリティ
  - 可読性
  - 保守性
  - コーディング規約の遵守

3. 必要に応じて、具体的な改善点を指摘する

</details>

<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)