### PR TITLE
[add] ファイル命名規則の強制の抽象仕様書・技術設計書を追加 (#112)

### DIFF
--- a/.sdd/specification/quality-guardrails/naming-enforcement_design.md
+++ b/.sdd/specification/quality-guardrails/naming-enforcement_design.md
@@ -1,0 +1,216 @@
+---
+id: "design-quality-guardrails-naming-enforcement"
+title: "ファイル命名規則の強制"
+type: "design"
+status: "draft"
+sdd-phase: "plan"
+impl-status: "implemented"
+created: "2026-07-08"
+updated: "2026-07-08"
+depends-on: ["spec-quality-guardrails-naming-enforcement"]
+tags: ["hooks", "naming-convention", "quality-gate"]
+category: "quality-guardrails"
+priority: "medium"
+risk: "medium"
+---
+
+# ファイル命名規則の強制
+
+**関連 Spec:** [naming-enforcement_spec.md](naming-enforcement_spec.md)
+**関連 PRD:** [naming-enforcement.md](../../requirement/quality-guardrails/naming-enforcement.md)（親: [quality-guardrails](../../requirement/quality-guardrails/index.md)）
+**準拠する原則:** [CONSTITUTION.md](../../CONSTITUTION.md) A-002（フックとスクリプトの責務分離）, D-002（ファイル命名規則の厳守）, T-003（日本語出力の文字化け防止）
+
+---
+
+# 1. 実装ステータス `<MUST>`
+
+**ステータス:** 🟢 実装済み
+
+本設計書は既存実装（`scripts/pre-tool-use.py` の命名規則検証パート）の挙動を逆算して記述したものである。
+検証対象パス・命名パターン・拒否条件は実装コードを真実の源とする。
+
+## 1.1. 実装進捗
+
+| モジュール/機能                       | ステータス | 備考                                                          |
+|---------------------------------|--------|-------------------------------------------------------------|
+| PreToolUse フックスクリプト（命名検証） | 🟢     | `scripts/pre-tool-use.py` の `validate_naming` 関数            |
+| フック共通ヘルパー                     | 🟢     | `scripts/hook_common.py`（stdin 解析・パス解決・deny emit）        |
+| パス設定の解決                        | 🟢     | `hook_common.load_sdd_paths`（`.sdd-config.json` 対応）         |
+| フック登録                          | 🟢     | `hooks/hooks.json` の `PreToolUse`（matcher: `Write|Edit`）    |
+| 回帰テスト                          | 🟢     | リポジトリルート `scripts/test-hook-scripts.sh`（適合・違反・対象外を検証。CI の `test` ジョブで実行） |
+
+---
+
+# 2. 設計目標 `<MUST>`
+
+- ファイル書き込み前に**軽量・決定的**に命名規則を検証し、応答性を阻害しない（NFR-001: 500ms 以内）
+- 命名規則違反を `permissionDecision: deny` で**確実にブロック**する（FR-004 / DC_001）
+- 適合時・検証対象外時は一切介入しない（FR-005）
+- 機械的な命名検証を Python スクリプトへ委譲し、Claude の推論を消費しない（A-002）
+
+---
+
+# 3. 実装方式 `<MUST>`
+
+| 領域   | 採用方式                                       | 選定理由                                                                                   |
+|------|--------------------------------------------|------------------------------------------------------------------------------------------|
+| hook | Python 3 スクリプト（文字列サフィックス照合）        | 決定的・軽量な検証であり Claude の推論を要さない。A-002 に従い機械的処理をスクリプトへ委譲し 500ms 要件を満たす |
+| hook | `permissionDecision: deny` によるブロック         | 命名規則違反は明確な違反条件であり、警告ではなく確実なブロックが必要（DC_001 が唯一 deny を許容する領域） |
+| パス設定 | `.sdd-config.json` からのディレクトリ名解決          | プロジェクト固有の `.sdd` ルート名・ディレクトリ名にも追従する。設定なし時は既定値にフォールバック         |
+| フック登録 | `hooks.json` の `PreToolUse`（matcher `Write|Edit`） | 書き込み前イベントを捕捉し、違反ファイルの生成そのものを防ぐ                                     |
+
+---
+
+# 4. アーキテクチャ `<MUST>`
+
+## 4.1. システム構成図
+
+```mermaid
+graph TD
+    CC[Claude Code: Write/Edit] --> RT[フックランタイム]
+    RT -->|stdin JSON| PTU[pre-tool-use.py]
+    PTU -->|read_stdin_json / get_project_root| HC[hook_common.py]
+    PTU -->|load_sdd_paths| CFG[.sdd-config.json]
+    PTU -->|relative_to_project| REL[プロジェクト相対パス]
+    REL -->|validate_naming| CHK{命名規則違反?}
+    CHK -->|違反| DENY[emit_permission_deny]
+    CHK -->|適合 / 対象外| PASS[出力なし / 許可]
+    DENY -->|permissionDecision: deny| CC
+```
+
+## 4.2. モジュール分割
+
+| モジュール名          | 責務                                                                          | 依存関係            | 配置場所                                        |
+|-------------------|-----------------------------------------------------------------------------|-----------------|-----------------------------------------------|
+| pre-tool-use.py   | 書き込み対象パスを検証し、命名規則違反時に deny を emit（`validate_naming`）             | hook_common.py, os, re | `plugins/sdd-workflow/scripts/pre-tool-use.py`  |
+| hook_common.py    | stdin JSON 解析・プロジェクトルート解決・`.sdd-config.json` 読み込み・deny の JSON 出力 | json, sys, os    | `plugins/sdd-workflow/scripts/hook_common.py`   |
+| hooks.json        | `PreToolUse`（matcher `Write|Edit`）へのスクリプト登録                          | -               | `plugins/sdd-workflow/hooks/hooks.json`         |
+
+`pre-tool-use.py` は命名検証に加え CONSTITUTION 原則注入も担うが、後者は別機能
+（[constitution-injection.md](../../requirement/quality-guardrails/constitution-injection.md)）の責務であり本設計書のスコープ外とする。
+
+---
+
+# 5. データ構造 `<OPTIONAL>`
+
+## 5.1. 検証ロジック（validate_naming）
+
+`validate_naming(rel_path, requirement_prefix, specification_prefix)` は、違反時に理由メッセージ文字列を、
+適合・対象外時に空文字列を返す。呼び出し元 `main` は事前に `relative_to_project` でプロジェクトルート外の
+パスを弾き（空文字列なら検証をスキップ）、以降を相対パスで判定する。判定手順は以下のとおり。
+
+0. パスがプロジェクトルート配下でなければ検証対象外（`main` が `relative_to_project` の空結果で `return`）
+1. 拡張子が `.md` でなければ対象外（空文字列を返す）
+2. ファイル名（basename）から `.md` を除いた `stem` を取り出す
+3. パスが `requirement/` プレフィックス配下: `stem` が `_spec` または `_design` で終わる場合は**違反**
+4. パスが `specification/` プレフィックス配下: `stem` が `_spec` にも `_design` にも該当しない場合は**違反**
+5. いずれの管理対象プレフィックスにも該当しない場合は対象外（空文字列を返す）
+
+| 対象ディレクトリ         | 判定条件                              | 違反例                              | 適合例                               |
+|-------------------|-------------------------------------|------------------------------------|-------------------------------------|
+| `requirement/`    | `_spec` / `_design` サフィックス**禁止** | `requirement/user-login_spec.md`   | `requirement/user-login.md`, `requirement/auth/index.md` |
+| `specification/`  | `_spec` / `_design` サフィックス**必須** | `specification/user-login.md`      | `specification/user-login_spec.md`, `specification/auth/index_design.md` |
+
+プレフィックスは `os.path.join(sdd_root, requirement_dir)` / `os.path.join(sdd_root, specification_dir)` で構築し、
+`rel_path.startswith(prefix + os.sep)` で照合する（既定では `.sdd/requirement` / `.sdd/specification`）。
+
+## 5.2. パス設定の解決（load_sdd_paths）
+
+`hook_common.load_sdd_paths(project_root)` が `(sdd_root, requirement_dir, specification_dir)` を返す。
+プロジェクトルートに `.sdd-config.json` が存在すれば `root` / `directories.requirement` /
+`directories.specification` の値で上書きし、なければ既定値（`.sdd` / `requirement` / `specification`）を用いる。
+
+## 5.3. 拒否出力（emit_permission_deny）
+
+命名規則違反時、`hook_common.emit_permission_deny("PreToolUse", reason)` が以下の JSON を標準出力へ emit する。
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "[AI-SDD] Naming violation: '<rel_path>'. <説明>"
+  }
+}
+```
+
+`json.dumps(..., ensure_ascii=False)` で出力する（T-003）。拒否理由には違反パスと、適合させるための具体例
+（`requirement/`: `user-login.md`, `index.md` / `specification/`: `user-login_spec.md`, `index_design.md`）を含める。
+
+---
+
+# 6. ファイル構成 `<OPTIONAL>`
+
+```
+plugins/sdd-workflow/
+├── scripts/
+│   ├── pre-tool-use.py      # PreToolUse フック本体（validate_naming で命名検証・違反時 deny）
+│   └── hook_common.py       # stdin 解析・パス解決・deny emit 共通ヘルパー
+└── hooks/
+    └── hooks.json           # PreToolUse（matcher: Write|Edit）へフックを登録
+```
+
+本機能はプラグインルートの `hooks.json` にフックが登録済みであり、新規スキル・エージェント追加ではないため
+`plugin.json` の変更は不要（T-002）。
+
+回帰テスト `scripts/test-hook-scripts.sh` は上記ツリー外の**リポジトリルート直下 `scripts/`** に配置され、
+CI（`.github/workflows/ci.yml` の `test` ジョブ）から実行される。本設計書中の `scripts/` は文脈により
+プラグイン配下（`plugins/sdd-workflow/scripts/`：フック本体）とリポジトリルート（テスト系）の 2 種を指すため注意する。
+
+---
+
+# 7. 非機能要件実現方針 `<OPTIONAL>`
+
+| 要件                          | 実現方針                                                                              |
+|-----------------------------|-------------------------------------------------------------------------------------|
+| NFR-001（500ms 以内）          | 外部プロセス・ネットワーク・LLM 呼び出しを行わず、標準ライブラリ（`os` / `re` / `json`）の文字列照合のみで同期処理する |
+| NFR-002（クロスプラットフォーム）   | POSIX 準拠の Python 3。パス区切りは `os.sep` / `os.path` を用い macOS・Linux 双方で動作する      |
+| NFR-003（フックイベント仕様準拠）    | `hookSpecificOutput.permissionDecision` 形式で emit。適合・対象外は無出力・exit code 0 で許可 |
+
+---
+
+# 8. テスト戦略 `<OPTIONAL>`
+
+| テストレベル       | 対象                                          | カバレッジ目標                                                        |
+|----------------|---------------------------------------------|--------------------------------------------------------------------|
+| 回帰テスト（hook） | リポジトリルート `scripts/test-hook-scripts.sh`   | 適合する spec 名の許可・`specification/` サフィックスなしの deny・拒否理由に違反文言を含む・`requirement/` への `_spec` の deny・`requirement/` サフィックスなしの許可・`.sdd/` 外ファイルの許可・不正 stdin の no-op |
+| CI 検証          | `.github/workflows/ci.yml` の `test` ジョブ     | フックスクリプト回帰テストが CI で実行される                                    |
+| 手動検証         | デモンストレーション                              | ファイル編集操作の体感遅延がない水準（NFR-001）                                 |
+
+---
+
+# 9. 設計判断 `<MUST>`
+
+## 9.1. 決定事項
+
+| 決定事項             | 選択肢                                | 決定内容                          | 理由                                                                 |
+|-------------------|-------------------------------------|---------------------------------|--------------------------------------------------------------------|
+| 検証の実装層          | フック（Python） / スキル（LLM）         | フック（Python スクリプト）           | A-002。決定的なサフィックス照合を LLM に委ねるとトークン浪費・応答遅延を招く            |
+| ブロッキング可否       | deny でブロック / 非ブロッキング警告       | deny でブロック                     | DC_001。命名規則違反はワークフロー整合性を破壊するため確実なブロックが必要（唯一の例外領域） |
+| 検証タイミング        | 書き込み前（PreToolUse） / 書き込み後       | 書き込み前（PreToolUse）             | 違反ファイルの生成そのものを防ぐ。書き込み後では違反ファイルが一度生成されてしまう        |
+| 検証対象拡張子        | 全ファイル / `.md` のみ                  | `.md` のみ                        | `.sdd/` ドキュメントは Markdown。図表・補助ファイル等の非 .md は命名規則の対象外   |
+| ディレクトリ名の解決    | ハードコード / `.sdd-config.json` から解決 | `.sdd-config.json` から解決（既定値あり） | プロジェクト固有のディレクトリ名に追従。設定なし時は既定値でゼロ設定動作を維持          |
+| 対象外パスの挙動       | 何か出力 / 無出力                        | 管理対象外は無出力で許可               | FR-005。`.sdd/` 外・`task/` 配下等の書き込みに一切介入しない                  |
+
+## 9.2. 未解決の課題
+
+| 課題                                | 影響度 | 対応方針                                                    |
+|-----------------------------------|-----|-----------------------------------------------------------|
+| 拒否理由メッセージが英語固定             | 低   | 現状フック出力は英語のみ。`SDD_LANG` に応じた多言語化は将来の別 Issue で検討 |
+| プレフィックス照合の想定外ディレクトリ構造   | 低   | `requirement/` / `specification/` 以外の構造は対象外。ネストや別名は `.sdd-config.json` で吸収 |
+| MultiEdit がフック対象外                | 低   | `pre-tool-use.py` の docstring は `Write|Edit|MultiEdit` と記載するが、`hooks.json` の matcher は `Write|Edit` で MultiEdit は現状発火しない。docstring の是正または matcher への MultiEdit 追加を別途検討 |
+| stem がサフィックスのみのファイル名        | 低   | `specification/_spec.md`（stem=`_spec`）等はサフィックス保有と判定され適合扱いになる。実害は小さく、退化ファイル名の扱い厳格化は将来検討 |
+| front matter 内容の検証は非対象         | -   | 本機能はファイル名のみ検証。内容検証は front-matter-validation 機能の責務（スコープ外） |
+
+---
+
+# 10. 原則準拠チェックリスト `<RECOMMENDED>`
+
+| 原則ID  | 原則名                    | 準拠状況 | 備考                                                        |
+|-------|--------------------------|--------|-----------------------------------------------------------|
+| A-002 | フックとスクリプトの責務分離   | ✅     | 機械的な命名検証を Python フックへ委譲し、Claude の推論を消費しない        |
+| D-002 | ファイル命名規則の厳守       | ✅     | requirement/ サフィックス禁止・specification/ サフィックス必須を deny で強制 |
+| B-001 | Vibe Coding 防止          | ✅     | ドキュメント種別を命名で識別する前提を守り、仕様書を真実の源とするフローを維持      |
+| DC_001 | ブロッキングの最小化        | ✅     | deny は命名規則違反のみに限定。適合・対象外は無介入                     |
+| IR_001 | フックイベント仕様準拠       | ✅     | `PreToolUse` の JSON Decision Control 仕様に準拠して emit         |
+| T-003 | 日本語出力の文字化け防止      | ✅     | `ensure_ascii=False` で出力（拒否理由に日本語を含む場合も文字化けを防止）    |

--- a/.sdd/specification/quality-guardrails/naming-enforcement_spec.md
+++ b/.sdd/specification/quality-guardrails/naming-enforcement_spec.md
@@ -1,0 +1,187 @@
+---
+id: "spec-quality-guardrails-naming-enforcement"
+title: "ファイル命名規則の強制"
+type: "spec"
+status: "draft"
+sdd-phase: "specify"
+created: "2026-07-08"
+updated: "2026-07-08"
+depends-on: ["prd-quality-guardrails-naming-enforcement"]
+tags: ["hooks", "naming-convention", "quality-gate"]
+category: "quality-guardrails"
+priority: "medium"
+risk: "medium"
+---
+
+# ファイル命名規則の強制
+
+**関連 Design Doc:** [naming-enforcement_design.md](naming-enforcement_design.md)
+**関連 PRD:** [naming-enforcement.md](../../requirement/quality-guardrails/naming-enforcement.md)（親: [quality-guardrails](../../requirement/quality-guardrails/index.md)）
+**準拠する原則:** [CONSTITUTION.md](../../CONSTITUTION.md) D-002（ファイル命名規則の厳守）, B-001（Vibe Coding 防止）, B-002（多言語対応の一貫性）
+
+---
+
+# 1. 背景 `<MUST>`
+
+`.sdd/` 配下のドキュメントは、ディレクトリとファイル名のサフィックスによって種別が識別される。
+`requirement/` 配下は要求仕様書（サフィックスなし）、`specification/` 配下は抽象仕様書（`_spec.md`）・
+技術設計書（`_design.md`）として扱われる。この命名規則は AI-SDD ワークフロー全体の前提であり、
+[CONSTITUTION.md](../../CONSTITUTION.md) の原則 D-002（ファイル命名規則の厳守）で非交渉原則として定義されている。
+
+命名規則に違反したファイルが書き込まれると、ドキュメント種別の識別が破綻し、後続の整合性チェック・
+ドキュメント間参照・ワークフロー自動化が機能しなくなる。人間や AI の注意力に依存した規約遵守は破られやすいため、
+本機能は違反ファイルの書き込みをフックで**構造的にブロック**し、規約遵守を強制する。
+
+# 2. 概要 `<MUST>`
+
+本機能は、`.sdd/` 配下へのファイル書き込み・編集イベントを捕捉し、ファイル名が命名規則に違反していないかを
+検証する。違反時は JSON Decision Control（`permissionDecision: deny`）により、理由を添えて書き込みを拒否する。
+主要な設計原則は以下のとおり。
+
+- **書き込み前検証**: ファイルが書き込まれる前（`PreToolUse`）に検証し、違反ファイルの生成そのものを防ぐ
+- **構造的ブロック**: 命名規則違反は警告に留めず `deny` で確実にブロックする（親 PRD DC_001 が唯一ブロックを許容する領域）
+- **軽量・決定的**: 判断は正規表現・文字列照合のみで完結し、LLM 推論やネットワークアクセスを行わない（NFR-001）
+- **設定可能なパス**: 検証対象ディレクトリ名は `.sdd-config.json` から解決し、プロジェクト固有のディレクトリ名にも追従する
+
+「何を検証し、どうブロックするか」を定義し、具体的な検証対象パス・判定条件・拒否メッセージ形式の詳細は
+[naming-enforcement_design.md](naming-enforcement_design.md) に委ねる。
+
+# 3. 要求定義 `<RECOMMENDED>`
+
+## 3.1. 機能要件 (Functional Requirements)
+
+| ID     | 要件                                                                       | 優先度 | 根拠（上流要求）                          |
+|--------|--------------------------------------------------------------------------|-----|-------------------------------------|
+| FR-001 | `.sdd/` 配下へのファイル書き込み・編集前に命名規則を検証する                     | 必須  | 子 PRD FR_001 / 親 PRD UR_004・FR_002 |
+| FR-002 | `requirement/` 配下のファイルに `_spec` / `_design` サフィックスがあれば拒否する | 必須  | 子 PRD FR_001                        |
+| FR-003 | `specification/` 配下のファイルに `_spec` / `_design` サフィックスがなければ拒否する | 必須  | 子 PRD FR_001                        |
+| FR-004 | 違反時は `permissionDecision: deny` により理由付きで書き込みをブロックする         | 必須  | 子 PRD FR_001 / 親 PRD DC_001・IR_001 |
+| FR-005 | 命名規則に適合する場合・検証対象外パスの場合はブロックせず開発フローに介入しない        | 必須  | 親 PRD DC_001（ブロッキングの最小化）から派生 |
+
+検証対象は `.md` ファイルのみとする。`requirement/` / `specification/` いずれの管理対象ディレクトリにも
+該当しないパス（`.sdd/` 外のソースコード、`task/` 配下等）は本機能の検証対象外とし、ブロックしない（FR-005）。
+
+## 3.2. 非機能要件 (Non-Functional Requirements)
+
+| ID      | カテゴリ         | 要件                                                       | 目標値                                     |
+|---------|--------------|----------------------------------------------------------|--------------------------------------------|
+| NFR-001 | 性能           | フック処理は軽量でファイル編集の応答性を阻害しない                 | スクリプト単体の実行時間 500ms 以内（親 PRD NFR_001） |
+| NFR-002 | 互換性         | macOS / Linux で動作する                                   | 親 PRD DC_004                              |
+| NFR-003 | インターフェース | Claude Code フックイベント仕様・JSON Decision Control に準拠する | 親 PRD IR_001                              |
+
+NFR-003 について、本機能は命名規則違反という明確な違反条件に対してのみ `deny` を用いる。適合時・対象外時は
+何も出力せず exit code 0 で正常終了し、書き込みを許可する（親 PRD DC_001）。
+
+# 4. 提供コンポーネント `<MUST>`
+
+| 種別   | 配置場所                                          | 名前                | 概要                                                                   |
+|------|-----------------------------------------------|-------------------|----------------------------------------------------------------------|
+| hook | `scripts/pre-tool-use.py` + `hooks/hooks.json` | PreToolUse フック    | `Write` / `Edit` の書き込み前に `.sdd/` ファイル命名規則を検証し、違反時に `deny` する（FR-001〜005） |
+
+`pre-tool-use.py` は本機能（命名規則検証）に加え、別機能である CONSTITUTION 原則注入
+（[constitution-injection.md](../../requirement/quality-guardrails/constitution-injection.md)）も担う。
+本仕様書は命名規則検証パートのみを対象とし、原則注入は当該子 PRD の仕様書で扱う。
+
+## 4.1. 入出力定義 `<OPTIONAL>`
+
+### PreToolUse フック（命名規則検証パート）
+
+**入力**: フックランタイムから stdin 経由で渡される JSON。少なくとも書き込み対象の `tool_input.file_path` を含む。
+検証対象ディレクトリ名はプロジェクトルートの `.sdd-config.json`（存在すれば）から解決する。
+
+**出力**: 命名規則違反を検知した場合のみ、`permissionDecision: deny` と違反理由を含む JSON を標準出力に emit する。
+適合時・検証対象外時は何も出力しない（FR-005）。
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "[AI-SDD] Naming violation: '...'. ..."
+  }
+}
+```
+
+# 5. 用語集 `<OPTIONAL>`
+
+| 用語                  | 説明                                                                            |
+|---------------------|-------------------------------------------------------------------------------|
+| 命名規則               | `requirement/` はサフィックスなし、`specification/` は `_spec.md` / `_design.md` 必須という規約 |
+| PreToolUse フック      | `Write` / `Edit` ツール実行の直前に発火する Claude Code のフックイベント                 |
+| JSON Decision Control | フックがツール実行の許可・拒否を JSON 出力（`permissionDecision`）で制御する Claude Code の仕組み      |
+| deny                | ツール実行をブロックする `permissionDecision` の値                                    |
+| `.sdd-config.json`   | `.sdd` ルート名・`requirement` / `specification` ディレクトリ名を上書き設定するプロジェクト設定ファイル |
+
+# 6. 使用例 `<RECOMMENDED>`
+
+```
+# specification/ にサフィックスなしのファイルを書こうとする → ブロック
+Write .sdd/specification/user-login.md
+  → deny: [AI-SDD] Naming violation: '.sdd/specification/user-login.md'.
+    Files under specification/ require a _spec.md or _design.md suffix ...
+
+# requirement/ に _spec サフィックス付きで書こうとする → ブロック
+Write .sdd/requirement/user-login_spec.md
+  → deny: [AI-SDD] Naming violation: '.sdd/requirement/user-login_spec.md'.
+    Files under requirement/ must not have a _spec/_design suffix ...
+
+# 命名規則に適合 → そのまま書き込み
+Write .sdd/specification/user-login_spec.md   → （介入なし・許可）
+Write .sdd/requirement/user-login.md          → （介入なし・許可）
+
+# .sdd/ 外のソースコード → 検証対象外
+Write src/main.py                             → （命名検証は介入なし）
+```
+
+# 7. 振る舞い図 `<OPTIONAL>`
+
+```mermaid
+sequenceDiagram
+    participant Claude as Claude Code
+    participant Runtime as フックランタイム
+    participant Hook as PreToolUse フック
+
+    Claude ->> Runtime: Write / Edit（file_path）
+    Runtime ->> Hook: tool_input を JSON で渡す
+    alt .md かつ requirement/ または specification/ 配下
+        alt 命名規則違反
+            Hook -->> Runtime: permissionDecision: deny（理由付き）
+            Runtime -->> Claude: 書き込み拒否
+        else 命名規則に適合
+            Hook -->> Runtime: 出力なし（許可）
+            Runtime ->> Claude: 書き込み実行
+        end
+    else 検証対象外パス
+        Hook -->> Runtime: 出力なし（許可）
+        Runtime ->> Claude: 書き込み実行
+    end
+```
+
+# 8. 制約事項 `<OPTIONAL>`
+
+- 本機能はファイル**名**のみを検証する。front matter の内容検証は
+  [front-matter-validation.md](../../requirement/quality-guardrails/front-matter-validation.md) の責務でありスコープ外。
+- 検証対象は `.md` ファイルに限定する。それ以外の拡張子は命名検証を行わない。
+- 本機能の発火対象は `Write` / `Edit` ツールに限定する（`MultiEdit` は現状スコープ外）。
+- ブロッキング動作（`deny`）は命名規則違反に限定する。他の品質ゲートは警告・促しに留める（親 PRD DC_001）。
+- 検証対象ディレクトリの判定はパスのプレフィックス照合に基づく。`.sdd-config.json` によるディレクトリ名の
+  カスタマイズには追従するが、想定外のディレクトリ構造は検証対象外として扱う。
+
+# 9. 原則との整合性 `<RECOMMENDED>`
+
+| 原則ID  | 原則名                    | 本仕様への適用内容                                                            |
+|-------|--------------------------|------------------------------------------------------------------------|
+| D-002 | ファイル命名規則の厳守       | 命名規則違反の書き込みを構造的にブロックし、規約遵守を強制する（本機能の存在意義）        |
+| B-001 | Vibe Coding 防止          | ドキュメント種別を命名で識別する前提を守り、仕様書を真実の源とするワークフローを維持する    |
+| B-002 | 多言語対応（EN/JA）の一貫性 | 拒否理由メッセージはフック出力の責務として定義（現状は英語固定、多言語化は将来検討）      |
+
+---
+
+# PRD 整合性レビュー結果
+
+| 確認項目             | 結果                                                                     |
+|--------------------|--------------------------------------------------------------------------|
+| 要求カバレッジ        | 子 PRD FR_001（requirement/ 禁止・specification/ 必須・deny によるブロック）を FR-001〜FR-004 に分解してカバー（FR-005 は親 PRD DC_001 から派生した spec 固有要求） |
+| 要求 ID 参照         | 各 FR に対応する子 PRD FR_001 / 親 PRD UR_004・FR_002・NFR_001・IR_001・DC_001 を「根拠」列に明記 |
+| 非機能要求の反映      | 親 PRD NFR_001・IR_001・DC_001 を NFR-001〜003 および制約事項に反映            |
+| 用語整合性           | 親 PRD 用語集の「JSON Decision Control」定義に統一。命名規則の定義は CLAUDE.md・D-002 に整合 |


### PR DESCRIPTION
## 概要

quality-guardrails カテゴリ（priority: medium）の子PRD「ファイル命名規則の強制」について、AI-SDD ワークフローに従い抽象仕様書（`_spec.md`）と技術設計書（`_design.md`）を生成した。既存実装 `pre-tool-use.py` の挙動を真実の源として design に反映している。

Closes #112

## 変更内容

- `.sdd/specification/quality-guardrails/naming-enforcement_spec.md` を新規追加
  - 子PRD FR_001 を FR-001〜FR-004 に分解、FR-005 は親PRD DC_001 由来の派生要求
  - トレーサビリティ表に子PRD FR_001 / 親PRD UR_004・FR_002・NFR_001・IR_001・DC_001 を明記
  - front matter: `id: spec-quality-guardrails-naming-enforcement` / `depends-on: [prd-quality-guardrails-naming-enforcement]`
- `.sdd/specification/quality-guardrails/naming-enforcement_design.md` を新規追加
  - 既存実装 `validate_naming` の挙動（`.md` 限定・`requirement/` サフィックス禁止・`specification/` サフィックス必須・`deny` 条件・`.sdd-config.json` パス解決）を反映
  - front matter: `id: design-quality-guardrails-naming-enforcement` / `depends-on: [spec-quality-guardrails-naming-enforcement]` / `impl-status: implemented`
- spec-reviewer / front-matter-reviewer のレビュー指摘を適用
  - MultiEdit の docstring/matcher 齟齬・プロジェクト外パス除外・stem サフィックスのみのエッジケースを design に追記
  - MultiEdit スコープ外を spec 制約事項に明記

## レビューの焦点

- 既存実装 `pre-tool-use.py` の挙動が design に正確に反映されているか
- トレーサビリティ表の要求ID参照が上流PRDと整合しているか
- 姉妹ファイル（vibe-detection_spec/design）との構成一貫性

## テスト計画

- [x] `bash scripts/plugin-lint.sh` 通過（Warnings 0 / Errors 0）
- [x] `bash scripts/validate-marketplace.sh` 通過
- [x] Markdownリンクの整合性確認（全相対リンク OK）
- [x] 文字化け（U+FFFD / mojibake）チェック通過

## 参考資料

- 子PRD: `.sdd/requirement/quality-guardrails/naming-enforcement.md`
- 親PRD: `.sdd/requirement/quality-guardrails/index.md`
- 既存実装: `plugins/sdd-workflow/scripts/pre-tool-use.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)