### PR TITLE
[add] generate-spec の抽象仕様書・技術設計書を追加

### DIFF
--- a/.sdd/specification/spec-design/generate-spec_design.md
+++ b/.sdd/specification/spec-design/generate-spec_design.md
@@ -1,0 +1,233 @@
+---
+id: "design-spec-design-generate-spec"
+title: "仕様書・設計書生成"
+type: "design"
+status: "draft"
+sdd-phase: "plan"
+impl-status: "implemented"
+created: "2026-07-08"
+updated: "2026-07-08"
+depends-on: ["spec-spec-design-generate-spec"]
+tags: ["specification", "design-doc", "generation"]
+category: "spec-design"
+priority: "high"
+risk: "high"
+---
+
+# 仕様書・設計書生成
+
+**関連 Spec:** [generate-spec_spec.md](generate-spec_spec.md)
+**関連 PRD:** [generate-spec.md](../../requirement/spec-design/generate-spec.md)（親: [spec-design](../../requirement/spec-design/index.md)）
+**準拠する原則:** [CONSTITUTION.md](../../CONSTITUTION.md) A-001（Skills-First）, A-002（フックとスクリプトの責務分離）, B-002（多言語対応の一貫性）, D-002（ファイル命名規則の厳守）, T-003（日本語出力の文字化け防止）
+
+---
+
+# 1. 実装ステータス `<MUST>`
+
+**ステータス:** 🟢 実装済み
+
+本設計書は既存実装（`skills/generate-spec/`）の挙動を逆算して記述したものである。
+トリガー方式（`/generate-spec` スキル呼び出し・`--ci` フラグ）・生成フロー・命名規則・
+テンプレート適用ロジックは実装コードを真実の源とする。
+
+## 1.1. 実装進捗
+
+| モジュール/機能              | ステータス | 備考                                                                     |
+|----------------------------|--------|------------------------------------------------------------------------|
+| generate-spec スキル本体      | 🟢     | `skills/generate-spec/SKILL.md`（2 フェーズ実行・生成ルール・front matter 規則） |
+| テンプレート前処理スクリプト     | 🟢     | `skills/generate-spec/scripts/prepare-spec.py`（テンプレート・参照のキャッシュ・環境変数エクスポート） |
+| 日英テンプレート              | 🟢     | `skills/generate-spec/templates/{en,ja}/`（spec_template / design_template / spec_output） |
+| 参照ドキュメント群            | 🟢     | `skills/generate-spec/references/`（生成フロー・front matter・既存文書チェック等） |
+| レビュー連携                 | 🟢     | `agents/spec-reviewer.md`・`agents/front-matter-reviewer.md` を生成後に呼び出す |
+| plugin.json 登録            | 🟢     | `.claude-plugin/plugin.json` の `skills` に登録済み（T-002）                   |
+
+---
+
+# 2. 設計目標 `<MUST>`
+
+- 入力内容から抽象度を分離した 2 層のドキュメント（spec / design）を生成する（FR-001 / FR-002 / DC_001）
+- 命名規則・テンプレート構造・front matter スキーマへの準拠を生成フローに組み込む（FR-003 / IR_001 / D-002）
+- 対応 PRD の構造（フラット / 階層）に追従して出力先と `id` を決定する（FR-004）
+- 決定的なファイル操作（テンプレート・参照のコピー、環境変数エクスポート）をスクリプトへ委譲し、
+  Claude は判断・生成に専念する 2 フェーズ実行とする（A-002）
+- 出力言語を `SDD_LANG` に従わせ、日本語出力の文字化けを防止する（NFR-001 / B-002 / T-003）
+- 生成前のリスク評価（FR-007）・生成後のレビュー連携（FR-008）・CI モード分岐（FR-009）を
+  スキルのオーケストレーション責務として組み込み、対話モードでは品質ゲートを維持する
+
+---
+
+# 3. 実装方式 `<MUST>`
+
+| 領域     | 採用方式                                          | 選定理由                                                                                          |
+|--------|-----------------------------------------------|-------------------------------------------------------------------------------------------------|
+| skill  | Markdown プロンプトスキル（`user-invocable: true`）   | 入力解析・仕様/設計の生成・整合レビューは Claude の推論を要する。A-001（Skills-First）に従いスキルとして実装 |
+| script | Python 3 スクリプト（2 フェーズ実行の前処理）            | テンプレート・参照のコピーと環境変数エクスポートは決定的操作。A-002 に従い機械的処理をスクリプトへ委譲しトークンを節約 |
+| 多言語   | `SDD_LANG` + `templates/{en,ja}/` + プロジェクト優先 | B-002 の一貫性要件。プロジェクトの `SPECIFICATION_TEMPLATE.md` を優先し、無ければ言語別スキルテンプレートを使う |
+| 出力先   | `SDD_*` 環境変数 + フラット/階層の分岐                | 出力先を環境変数で解決し、対応 PRD の構造に追従して保存パスと `id` を決定する（FR-004）                     |
+| レビュー連携（FR-008） | サブエージェント呼び出し（Task 相当）              | 生成後の原則準拠・front matter 検証を spec-reviewer / front-matter-reviewer に委譲（責務分離）。各文書生成直後に逐次呼び出す |
+
+---
+
+# 4. アーキテクチャ `<MUST>`
+
+## 4.1. システム構成図
+
+```mermaid
+graph TD
+    U[開発者: /generate-spec 要件記述] --> SK[generate-spec SKILL.md]
+    SK -->|Phase 1: 前処理| PS[prepare-spec.py]
+    PS -->|.sdd-config.json 読取| CFG[lang / root]
+    PS -->|テンプレート/参照コピー| CACHE[.sdd/.cache/generate-spec]
+    PS -->|環境変数 export| ENV[CLAUDE_ENV_FILE]
+    SK -->|Phase 2: 生成| GEN[Claude: 入力解析・生成]
+    GEN -->|CONSTITUTION.md 読取| CONST[原則準拠]
+    GEN -->|対応 PRD 確認| PRD[要求 ID / 構造]
+    GEN -->|spec 生成| SPEC[{feature}_spec.md]
+    GEN -->|design 生成| DESIGN[{feature}_design.md]
+    SPEC --> RVS[spec / front-matter reviewer（spec）]
+    DESIGN --> RVD[spec / front-matter reviewer（design）]
+    RVS -->|指摘| GEN
+    RVD -->|指摘| GEN
+```
+
+レビューは文書ごとに逐次実行する（spec 生成 → spec のレビュー → design 生成 → design のレビュー）。
+`--ci` モードではリスク評価とレビューを省略する（FR-009）。
+
+## 4.2. モジュール分割
+
+| モジュール名                | 責務                                                                       | 依存関係                         | 配置場所                                                    |
+|--------------------------|--------------------------------------------------------------------------|--------------------------------|-----------------------------------------------------------|
+| generate-spec SKILL.md   | 入力解析・リスク評価（FR-007）・spec/design 生成（FR-001/002）・整合レビュー連携（FR-008）・CI モード分岐（FR-009）のオーケストレーション | prepare-spec.py, spec-reviewer, front-matter-reviewer | `plugins/sdd-workflow/skills/generate-spec/SKILL.md`      |
+| prepare-spec.py          | テンプレート/参照のキャッシュコピーと `GENERATE_SPEC_*` 環境変数のエクスポート（前処理） | os, sys, json, shutil, pathlib | `plugins/sdd-workflow/skills/generate-spec/scripts/prepare-spec.py` |
+| templates/{en,ja}/       | spec / design / 出力レポートの言語別テンプレート                                 | SDD_LANG                       | `plugins/sdd-workflow/skills/generate-spec/templates/{en,ja}/` |
+| references/              | 生成フロー・front matter 規則・既存文書チェック・前提条件の参照ドキュメント             | -                              | `plugins/sdd-workflow/skills/generate-spec/references/`   |
+| spec-reviewer（外部）      | 生成物の CONSTITUTION 準拠・トレーサビリティ・SysML 妥当性のレビュー                  | Read/Glob/Grep/AskUserQuestion | `plugins/sdd-workflow/agents/spec-reviewer.md`            |
+| front-matter-reviewer（外部） | front matter の形式・依存方向・id 一意性の検証                                  | Read/Glob/Grep                 | `plugins/sdd-workflow/agents/front-matter-reviewer.md`    |
+
+---
+
+# 5. データ構造 `<OPTIONAL>`
+
+## 5.1. 前処理スクリプトの環境変数エクスポート
+
+`prepare-spec.py` は `.sdd-config.json` から `lang` / `root` を読み取り、テンプレートと参照を
+`{root}/.cache/generate-spec/` にコピーしたうえで、`CLAUDE_ENV_FILE` に以下を追記する。
+既存の `GENERATE_SPEC_*` 行は事前に除去してから書き込む（再実行時の重複防止）。
+
+```sh
+export GENERATE_SPEC_CACHE_DIR="{root}/.cache/generate-spec"
+export GENERATE_SPEC_SPEC_TEMPLATE="{root}/.cache/generate-spec/spec_template.md"
+export GENERATE_SPEC_DESIGN_TEMPLATE="{root}/.cache/generate-spec/design_template.md"
+export GENERATE_SPEC_REFERENCES="{root}/.cache/generate-spec/references"
+```
+
+テンプレート解決の優先順位は「プロジェクトの `{root}/SPECIFICATION_TEMPLATE.md`・
+`{root}/DESIGN_DOC_TEMPLATE.md` → 無ければスキルの `templates/{lang}/`」である。
+なお `prepare-spec.py` はテンプレートのコピーのみを担い、プロジェクトテンプレートが不在の場合に
+スキルテンプレートを基にプロジェクトの `*_TEMPLATE.md` を生成する処理は Phase 2（Claude）が担う。
+
+## 5.2. 生成物の front matter スキーマ
+
+| フィールド      | spec                                    | design                                     |
+|--------------|-----------------------------------------|--------------------------------------------|
+| `id`          | `spec-{feature}` / 階層: `spec-{parent}-{feature}` | `design-{feature}` / 階層: `design-{parent}-{feature}` |
+| `type`        | `"spec"`                                | `"design"`                                 |
+| `sdd-phase`   | `"specify"`                             | `"plan"`                                   |
+| `status`      | `"draft"`（新規）                         | `"draft"`（新規）                            |
+| `impl-status` | —                                       | `"not-implemented"`（新規）                  |
+| `depends-on`  | PRD ID（例: `["prd-{feature}"]`）         | spec ID（例: `["spec-{feature}"]`）          |
+| `priority` / `risk` | PRD から継承（無ければ `"medium"`）        | spec から継承                                |
+
+**依存方向は上流のみ**（`prd ← spec ← design`）。下位ドキュメントへの参照は持たない。
+
+## 5.3. 出力先パスの決定
+
+| 構造            | spec                                                | design                                                |
+|---------------|-----------------------------------------------------|-------------------------------------------------------|
+| フラット         | `{SDD_SPECIFICATION_PATH}/{feature}_spec.md`         | `{SDD_SPECIFICATION_PATH}/{feature}_design.md`         |
+| 階層（親機能）     | `{SDD_SPECIFICATION_PATH}/{parent}/index_spec.md`    | `{SDD_SPECIFICATION_PATH}/{parent}/index_design.md`    |
+| 階層（子機能）     | `{SDD_SPECIFICATION_PATH}/{parent}/{feature}_spec.md` | `{SDD_SPECIFICATION_PATH}/{parent}/{feature}_design.md` |
+
+対応 PRD が階層構造で存在する場合、または入力で親機能（カテゴリ）が指定された場合に階層構造を用いる。
+
+---
+
+# 6. ファイル構成 `<OPTIONAL>`
+
+```
+plugins/sdd-workflow/
+├── skills/generate-spec/
+│   ├── SKILL.md                  # スキル本体（2 フェーズ実行・生成ルール・front matter 規則）
+│   ├── scripts/
+│   │   └── prepare-spec.py       # Phase 1: テンプレート/参照のキャッシュ・環境変数 export
+│   ├── templates/{en,ja}/        # spec_template / design_template / spec_output
+│   ├── references/               # generation_flow / front_matter_spec_design / existing_document_check 等
+│   └── examples/                 # 入力例・整合性チェック出力例・検証コマンド例
+├── agents/
+│   ├── spec-reviewer.md          # 生成後の原則準拠・トレーサビリティレビュー（外部連携）
+│   └── front-matter-reviewer.md  # 生成後の front matter 検証（外部連携）
+└── .claude-plugin/plugin.json    # skills に generate-spec を登録（T-002）
+```
+
+生成先は本プラグイン外の対象プロジェクトの `${SDD_SPECIFICATION_PATH}`（既定 `.sdd/specification/`）である。
+
+---
+
+# 7. 非機能要件実現方針 `<OPTIONAL>`
+
+| 要件                                    | 実現方針                                                                                     |
+|---------------------------------------|--------------------------------------------------------------------------------------------|
+| NFR-001（言語の一貫性）                    | `SDD_LANG` に従い `templates/{en,ja}/` を選択。プロジェクト優先テンプレートも同一言語で運用             |
+| NFR-002（命名規則・テンプレート・front matter 準拠） | 生成フロー内でサフィックス・テンプレート必須セクション・front matter スキーマを検証し、front-matter-reviewer で再確認 |
+| NFR-003（移植性）                         | 前処理は標準ライブラリのみの Python 3。`CLAUDE_PROJECT_DIR` 未設定時は git root / cwd にフォールバック |
+| T-003（文字化け防止）                       | 日本語テンプレート・生成物で UTF-8 を維持し、mojibake / U+FFFD の混入を出力前に確認                    |
+
+---
+
+# 8. テスト戦略 `<OPTIONAL>`
+
+| テストレベル       | 対象                                          | カバレッジ目標                                          |
+|----------------|---------------------------------------------|------------------------------------------------------|
+| 手動検証（デモ）    | `/generate-spec` の spec / design 生成           | 命名規則準拠・テンプレート必須セクション網羅・front matter 妥当性 |
+| 静的検査          | 生成物のマークダウンリンク・front matter               | spec-reviewer / front-matter-reviewer による検証        |
+| Lint            | プロンプトファイルの構文・命名規則                       | リポジトリの `plugin-lint`（CI の `plugin-lint` ジョブ）      |
+
+本機能は入力依存の生成であり自動ユニットテストは持たない。品質は生成後のレビューエージェント連携（FR-008）で担保する。
+
+---
+
+# 9. 設計判断 `<MUST>`
+
+## 9.1. 決定事項
+
+| 決定事項              | 選択肢                                  | 決定内容                          | 理由                                                                       |
+|--------------------|-----------------------------------------|-----------------------------------|--------------------------------------------------------------------------|
+| 実行方式             | 単一プロンプト / 2 フェーズ（スクリプト+Claude） | 2 フェーズ実行                      | A-002。テンプレート/参照のコピーは決定的操作でありスクリプト化しトークンを節約する         |
+| テンプレート解決順     | スキル固定 / プロジェクト優先              | プロジェクト `{root}/*_TEMPLATE.md` を優先 | プロジェクト固有のテンプレート差異を尊重し、無い場合のみ言語別スキルテンプレートにフォールバック |
+| 抽象度の分離          | 単一ドキュメント / spec と design の 2 層    | 2 層に分離                         | DC_001。spec は「何を」、design は「どのように」に責務を分け、ガードレールとして機能させる |
+| レビューの内製 / 外部委譲 | スキル内で完結 / 外部エージェントへ委譲       | spec-reviewer / front-matter-reviewer へ委譲 | 品質レビュー・front matter 検証は独立責務であり、専用エージェントへ委譲して重複を避ける（責務分離） |
+| CI モードの挙動        | 常に対話 / `--ci` で省略                   | `--ci` でリスク評価・レビューを省略し上書き自動承認・Design Doc を常時生成 | 非対話パイプラインでの自動生成を可能にする。生成省略の確認を挟まず design まで必ず生成し、対話モードでは品質ゲートを維持する（FR-009） |
+| 出力エンコーディング    | ASCII エスケープ / UTF-8                   | UTF-8 を維持                       | T-003。日本語生成物の文字化けを防止する                                            |
+
+## 9.2. 未解決の課題 `<OPTIONAL>`
+
+| 課題                                       | 影響度 | 対応方針                                                          |
+|------------------------------------------|-----|-----------------------------------------------------------------|
+| 生成品質が基盤モデルの能力に依存する               | 中   | 生成後のレビューエージェント連携（FR-008）で担保。将来のモデル更新で改善            |
+| spec-reviewer 連携が spec-review 機能と責務境界を跨ぐ | 低   | 本機能は呼び出し（オーケストレーション）のみを担い、レビュー本体は spec-review 機能を正典とする |
+
+---
+
+# 10. 原則準拠チェックリスト `<RECOMMENDED>`
+
+| 原則ID  | 原則名                       | 準拠状況 | 備考                                                            |
+|-------|-----------------------------|--------|---------------------------------------------------------------|
+| A-001 | Skills-First                 | ✅     | `skills/generate-spec/` として実装（legacy commands 不使用）           |
+| A-002 | フックとスクリプトの責務分離       | ✅     | テンプレート/参照コピーは `prepare-spec.py`、判断・生成は Claude に分離        |
+| B-002 | 多言語対応（EN/JA）の一貫性       | ✅     | `SDD_LANG` + `templates/{en,ja}/`。プロジェクト優先テンプレートも言語一貫      |
+| D-001 | Specification-Driven          | ✅     | spec / design を生成し Specify → Plan フローを支える中核機能               |
+| D-002 | ファイル命名規則の厳守            | ✅     | `_spec` / `_design` サフィックスと構造別パスを生成フローで強制                 |
+| T-002 | plugin.json 登録の徹底          | ✅     | `skills` に generate-spec を登録済み                                |
+| T-003 | 日本語出力の文字化け防止           | ✅     | 生成物の UTF-8 維持・mojibake / U+FFFD の混入を出力前に確認                 |
+
+**原則から逸脱する場合**: 理由を「9.1. 決定事項」に明記し、CONSTITUTION.md の例外プロセスに従うこと。

--- a/.sdd/specification/spec-design/generate-spec_spec.md
+++ b/.sdd/specification/spec-design/generate-spec_spec.md
@@ -1,0 +1,203 @@
+---
+id: "spec-spec-design-generate-spec"
+title: "仕様書・設計書生成"
+type: "spec"
+status: "draft"
+sdd-phase: "specify"
+created: "2026-07-08"
+updated: "2026-07-08"
+depends-on: ["prd-spec-design-generate-spec"]
+tags: ["specification", "design-doc", "generation"]
+category: "spec-design"
+priority: "high"
+risk: "high"
+---
+
+# 仕様書・設計書生成
+
+**関連 Design Doc:** [generate-spec_design.md](generate-spec_design.md)
+**関連 PRD:** [generate-spec.md](../../requirement/spec-design/generate-spec.md)（親: [spec-design](../../requirement/spec-design/index.md)）
+**準拠する原則:** [CONSTITUTION.md](../../CONSTITUTION.md) B-001（Vibe Coding 防止）, B-002（多言語対応の一貫性）, A-001（Skills-First）, D-001（Specification-Driven）, D-002（ファイル命名規則の厳守）
+
+---
+
+# 1. 背景 `<MUST>`
+
+AI-SDD ワークフローでは、PRD（何を・なぜ）から抽象仕様書（`*_spec.md`: 何を）と技術設計書
+（`*_design.md`: どのように）へ段階的に具体化することで、AI 実装者へのガードレールを構築する。
+この Specify / Plan フェーズの成果物が存在しなければ、AI は未定義の要求を推測して実装する
+Vibe Coding 問題（[CONSTITUTION.md](../../CONSTITUTION.md) B-001）に陥る。
+
+本機能は、開発者の入力内容（PRD・要件記述）から 2 層のドキュメントを生成し、抽象度を分離した
+真実の源（Single Source of Truth）を構築する。仕様書・設計書の生成を開発者の手作業に依存させず、
+命名規則・テンプレート・front matter への準拠を含めて一貫した品質で提供することを狙いとする。
+
+# 2. 概要 `<MUST>`
+
+本機能は、入力内容から抽象仕様書と技術設計書を生成し、`specification` ディレクトリに保存する。
+主要な設計原則は以下のとおり。
+
+- **段階的な具体化**: 「何を作るか」の抽象仕様書と「どのように実現するか」の技術設計書を、抽象度を
+  分離した 2 層で生成する（親 PRD UR_001・DC_001 に準拠）
+- **上流トレーサビリティ**: 対応する PRD が存在する場合、その要求 ID（UR/FR/NFR）を仕様書に参照し、
+  PRD → spec → design の依存方向を保つ（親 PRD IR_001）
+- **規約準拠**: 命名規則（`_spec.md` / `_design.md` サフィックス必須）・テンプレート構造・
+  front matter スキーマへの準拠を生成物に強制する（親 PRD IR_001 / 原則 D-002）
+- **構造追従**: 対応する PRD の構造（フラット / 階層）に追従して出力先を決定する
+- **言語の一貫性**: 生成物の言語は `SDD_LANG` 環境変数に従い、単一ドキュメント内で混在させない
+  （親 PRD DC_002 / 原則 B-002）
+- **Vibe Coding 防止との連携**: 生成前に入力の曖昧性を評価し、生成後に外部レビューエージェントで
+  整合を確認するオーケストレーションを担う
+
+「何を生成し、どの規約に準拠するか」を定義し、テンプレートの前処理方式・生成フローの実行手順・
+front matter の具体スキーマの詳細は [generate-spec_design.md](generate-spec_design.md) に委ねる。
+
+# 3. 要求定義 `<RECOMMENDED>`
+
+## 3.1. 機能要件 (Functional Requirements)
+
+| ID     | 要件                                                                          | 優先度 | 根拠（上流要求）                                     |
+|--------|-------------------------------------------------------------------------------|-----|--------------------------------------------------|
+| FR-001 | 入力内容（PRD・要件記述）から抽象仕様書（`{feature-name}_spec.md`）を生成し保存する          | 必須  | 子 PRD FR_001 / 親 PRD UR_001・FR_001         |
+| FR-002 | 抽象仕様書を入力として技術設計書（`{feature-name}_design.md`）を生成し保存する            | 必須  | 子 PRD FR_001 / 親 PRD UR_001・FR_001         |
+| FR-003 | 生成物を命名規則（`_spec` / `_design` サフィックス必須）・テンプレート構造・front matter スキーマに準拠させる | 必須  | 子 PRD IR_001 / 親 PRD IR_001                 |
+| FR-004 | 対応する PRD の構造（フラット / 階層）に追従して出力先パスと front matter の `id` を決定する      | 必須  | 子 PRD FR_001 / 親 PRD IR_001                 |
+| FR-005 | PRD が存在する場合、生成時に要求 ID（UR/FR/NFR）を仕様書に参照付与し、要求カバレッジを確認する       | 必須  | 親 PRD UR_001・IR_001                          |
+| FR-006 | 抽象仕様書に技術詳細を含めず、技術設計書に設計判断の理由を明示し、抽象度を分離する               | 必須  | 子 PRD DC_001 / 親 PRD DC_001                  |
+| FR-007 | 生成前に入力の曖昧性（Vibe Coding リスク）を評価し、高リスク時は生成前に不足情報を確認する         | 必須  | 親 PRD B-001（CONSTITUTION）から派生            |
+| FR-008 | 生成後に外部レビューエージェント（spec-reviewer / front-matter-reviewer）を呼び出し、原則準拠・front matter を検証して指摘を反映する | 必須  | 親 PRD IR_001（検証） |
+| FR-009 | 非対話（CI）モードでは曖昧性評価・レビューを省略し、既存ファイルの上書きを自動承認し、Design Doc を常に生成する（生成省略の確認を行わない） | 任意  | 運用要求（自動化）から派生                          |
+
+FR-005 は生成時の PRD 整合（要求カバレッジ確認・要求 ID 参照付与）を担い、FR-008 は生成後に外部エージェントで
+原則・front matter を検証する責務であり、両者は目的が異なる。FR-007・FR-008 は生成の前後に位置する連携責務であり、
+曖昧性評価そのものは vibe-detector、品質レビューそのものは spec-review 機能が正典として扱う
+（本機能はそれらを呼び出すオーケストレーションを担う）。
+
+## 3.2. 非機能要件 (Non-Functional Requirements) `<OPTIONAL>`
+
+| ID      | カテゴリ         | 要件                                                            | 目標値 / 根拠                                   |
+|---------|--------------|-----------------------------------------------------------------|-----------------------------------------------|
+| NFR-001 | 一貫性          | 生成物の言語は `SDD_LANG`（en / ja）に従い、単一文書内で混在させない      | 言語混在ゼロ（親 PRD DC_002 / 原則 B-002）        |
+| NFR-002 | インターフェース  | 命名規則・テンプレート・front matter スキーマに準拠する                    | レビューで違反ゼロ（親 PRD IR_001）                |
+| NFR-003 | 移植性          | Claude Code のスキル機構上で動作し、macOS / Linux で前処理が実行できる      | 標準ライブラリのみで前処理成功（親 PRD 制約 5.1）    |
+
+# 4. 提供コンポーネント `<MUST>`
+
+| 種別    | 配置場所                              | 名前            | 概要                                                                     |
+|-------|-----------------------------------|---------------|------------------------------------------------------------------------|
+| skill | `skills/generate-spec/SKILL.md`   | generate-spec | 入力内容から抽象仕様書・技術設計書を生成する user-invocable スキル（FR-001〜FR-009） |
+
+本機能が呼び出す `spec-reviewer` / `front-matter-reviewer` エージェント（FR-008）は spec-review 機能・
+front-matter 検証機能が正典として提供するコンポーネントであり、本機能はそれらを連携利用する。
+
+## 4.1. 入出力定義 `<OPTIONAL>`
+
+### generate-spec スキル
+
+**入力**:
+
+- 要件記述テキスト（必須）。機能名を記述から抽出・推論する
+- `--ci` フラグ（任意）。CI / 非対話モードを指定する（FR-009）
+- 環境変数 `SDD_LANG`（出力言語）・`SDD_ROOT` / `SDD_SPECIFICATION_PATH`（出力先の解決）
+
+**出力**:
+
+- `{feature-name}_spec.md`（抽象仕様書）と `{feature-name}_design.md`（技術設計書）。
+  出力先はフラット / 階層の構造に従う
+- 生成結果と整合性レビュー結果を含むレポート（出力言語は `SDD_LANG` に従う）
+
+front matter の共通・種別固有フィールドの構造例（詳細スキーマは Design Doc を参照）:
+
+```yaml
+# spec
+id: "spec-{parent}-{feature-name}"   # 階層構造の場合はパスを含める
+type: "spec"
+sdd-phase: "specify"
+depends-on: ["prd-{parent}-{feature-name}"]   # 上流方向のみ
+
+# design
+id: "design-{parent}-{feature-name}"
+type: "design"
+sdd-phase: "plan"
+impl-status: "not-implemented"
+depends-on: ["spec-{parent}-{feature-name}"]   # 上流方向のみ
+```
+
+# 5. 用語集 `<OPTIONAL>`
+
+| 用語        | 説明                                                                                |
+|-----------|-------------------------------------------------------------------------------------|
+| 抽象仕様書    | `{name}_spec.md`。「何を作るか」を技術詳細抜きで定義する Specify フェーズの成果物              |
+| 技術設計書    | `{name}_design.md`。「どのように実現するか」と設計判断の理由を定義する Plan フェーズの成果物     |
+| フラット構造   | `specification/{name}_spec.md` のように親ディレクトリを持たない小〜中規模向けの配置          |
+| 階層構造     | `specification/{parent}/{name}_spec.md` のように親機能ディレクトリ配下に配置する中〜大規模向けの配置 |
+| 要求カバレッジ | PRD の全要求 ID（UR/FR/NFR）のうち、仕様書で対応が確認できる要求の割合                        |
+| Vibe Coding | 曖昧な指示により AI が仕様を暗黙的に推測して実装してしまう問題（CONSTITUTION.md B-001 の定義に従う） |
+
+# 6. 使用例 `<RECOMMENDED>`
+
+```
+# 要件記述から spec / design を生成（対話モード）
+/generate-spec ユーザーログイン機能。メールとパスワードで認証しセッションを発行する
+  → user-login_spec.md と user-login_design.md を生成
+    （生成前に曖昧性を確認し、生成後に spec-reviewer / front-matter-reviewer で検証）
+
+# CI / 非対話モード（曖昧性評価・レビューを省略し上書きを自動承認）
+/generate-spec ユーザーログイン機能 --ci
+```
+
+# 7. 振る舞い図 `<OPTIONAL>`
+
+```mermaid
+sequenceDiagram
+    participant User as 開発者
+    participant Skill as generate-spec
+    participant PRD as 既存 PRD
+    participant Reviewer as spec-reviewer / front-matter-reviewer
+
+    User ->> Skill: 要件記述（+ --ci）
+    alt 対話モード
+        Skill ->> Skill: Vibe Coding リスク評価（FR-007）
+        Skill -->> User: 高リスク時は不足情報を確認
+    end
+    Skill ->> PRD: 対応 PRD と構造（フラット / 階層）を確認
+    PRD -->> Skill: 要求 ID（UR/FR/NFR）
+    Skill ->> Skill: 抽象仕様書を生成（FR-001, 規約準拠 FR-003）
+    Skill ->> Skill: 技術設計書を生成（FR-002）
+    alt 対話モード
+        Skill ->> Reviewer: 生成物のレビュー依頼（FR-008）
+        Reviewer -->> Skill: 原則準拠・front matter 指摘
+        Skill ->> Skill: 指摘を反映
+    end
+    Skill -->> User: 生成結果 + 整合性レビュー結果
+```
+
+# 8. 制約事項 `<OPTIONAL>`
+
+- 本機能は Claude Code のスキル機構上で動作し、生成品質は基盤モデルの能力に依存する（親 PRD 制約 5.1）
+- 生成前の仕様明確化（clarify）・生成後の品質レビュー本体（spec-review）・既存実装からの逆算
+  （plan-refactor）は本機能のスコープ外であり、兄弟機能が扱う（子 PRD スコープ外）
+- PRD 自体の生成は prd-generation カテゴリのスコープ外とする（子 PRD スコープ外）
+- 抽象仕様書には技術的実装詳細（アーキテクチャ・技術スタック・API 定義・スキーマ）を含めない（DC_001）
+
+# 9. 原則との整合性 `<RECOMMENDED>`
+
+| 原則ID  | 原則名                    | 本仕様への適用内容                                                              |
+|-------|--------------------------|------------------------------------------------------------------------|
+| B-001 | Vibe Coding 防止          | 生成前に入力の曖昧性を評価し、仕様書を真実の源として構築することで暗黙的な要求推測を排除する  |
+| B-002 | 多言語対応（EN/JA）の一貫性 | 生成物の言語を `SDD_LANG` に従わせ、単一ドキュメント内で言語を混在させない（NFR-001）    |
+| A-001 | Skills-First              | 本機能を legacy commands ではなく `skills/generate-spec/` として提供する          |
+| D-001 | Specification-Driven      | 実装前に spec / design を生成し、Specify → Plan のフローを支える中核機能とする        |
+| D-002 | ファイル命名規則の厳守       | 生成物に `_spec` / `_design` サフィックスと命名規則表への準拠を強制する（FR-003）      |
+
+---
+
+# PRD 整合性レビュー結果
+
+| 確認項目          | 結果                                                                                       |
+|-----------------|------------------------------------------------------------------------------------------|
+| 要求カバレッジ     | 子 PRD FR_001 とそのサブ範囲（spec 生成・design 生成・規約準拠）を FR-001〜FR-004・FR-006 でカバー |
+| 要求 ID 参照      | 各 FR に対応する子 PRD / 親 PRD の要求 ID を「根拠」列に明記                                       |
+| 非機能要求の反映   | 親 PRD IR_001・DC_001・DC_002 を FR-003・FR-006 および NFR-001〜002 に反映                       |
+| 用語整合性        | 親 PRD 用語集の「抽象仕様書」「技術設計書」定義に統一。「フラット / 階層構造」は CLAUDE.md の定義に整合  |
+| スコープ整合      | 親 PRD NFR_001（明確度スコア）は clarify 機能の要求のため本仕様の対象外とし、意図的に非カバーとした    |


### PR DESCRIPTION
## 概要

spec-design カテゴリの子PRD「仕様書・設計書生成」（`generate-spec`）について、AI-SDD ワークフローに従い抽象仕様書（`_spec.md`）と技術設計書（`_design.md`）を追加する。既存実装（`skills/generate-spec/`）を真実の源として逆算し、トリガー方式・命名規則・テンプレート適用・2フェーズ実行を design に反映した。

Closes #121

## 変更内容

- [x] `generate-spec_spec.md` を追加（階層構造 `.sdd/specification/spec-design/` 配下）
- [x] `generate-spec_design.md` を追加（同上）
- [x] トレーサビリティ表に子PRD `FR_001`・親PRD `UR_001`/`IR_001`/`DC_001`/`DC_002` の要求IDを記載し、`PRD → spec → design` の依存方向を維持
- [x] front matter を指定どおり設定（spec: `id: spec-spec-design-generate-spec` / `depends-on: [prd-spec-design-generate-spec]`、design: `id: design-spec-design-generate-spec` / `depends-on: [spec-spec-design-generate-spec]`）
- [x] 既存実装の挙動（`prepare-spec.py` による2フェーズ実行・テンプレート解決順・命名規則準拠・spec-reviewer/front-matter-reviewer 連携・`--ci` モード）を design に逆算反映
- [x] 親PRD `NFR_001`（明確度スコア）は clarify 機能の要求のため意図的に非カバーとし、PRD整合性レビュー結果に明記

## レビューの焦点

- **抽象度の分離（DC_001）**: spec に技術詳細を持ち込まず、Python・環境変数・キャッシュパス等は design に集約できているか
- **逆算精度**: `.sdd/specification/spec-design/generate-spec_design.md` の実装方式・データ構造が既存実装（`plugins/sdd-workflow/skills/generate-spec/SKILL.md`・`scripts/prepare-spec.py`）と一致しているか
- **トレーサビリティ**: 各FRの上流要求ID参照が正しいか

`spec-reviewer` / `front-matter-reviewer` でレビュー済み。front-matter は指摘0件、spec-reviewer の [must]/[recommend] 指摘（FR-007〜009 の design 反映、`--ci` の Design Doc 常時生成、テンプレート自動生成挙動、レビュー逐次性、NFR目標値列）を適用済み。

## テスト計画

- [x] `cat plugins/*/.claude-plugin/*.json | jq .` JSON構文チェック通過（プラグイン変更なし）
- [ ] `claude --plugin-dir ./plugins/sdd-workflow` でローカルテスト確認
- [x] Markdownリンクの整合性確認（全相対リンクの実在を確認済み）
- [x] 日本語出力の文字化け（U+FFFD / mojibake）混入なしを確認

## 参考資料

- Closes #121
- 子PRD: `.sdd/requirement/spec-design/generate-spec.md`
- 親PRD: `.sdd/requirement/spec-design/index.md`


<!-- for GitHub Copilot review rule -->

<details>
<summary>for GitHub Copilot review rule</summary>

## お願い

- 日本語で回答してください
- 簡潔で分かりやすい説明を心がけてください
- ベストプラクティスの具体例を提示してください
- 指摘の根拠となる情報源や学習リソースの提案を積極的に行ってください

## レビュールール

以下のプレフィックスを使用してレビューコメントを分類してください：

- \`[must]\` - 必須修正項目（セキュリティ、バグ、重大な設計問題）
- \`[recommend]\` - 推奨修正項目（パフォーマンス、可読性の大幅改善）
- \`[nits]\` - 軽微な指摘（コードスタイル、タイポ等）

## レビューステップ

1. コードの差分よりPRの概要を作成する

2. 実際にコードを確認し、以下の観点でレビューを行う
  - コードの正確性
  - パフォーマンス
  - セキュリティ
  - 可読性
  - 保守性
  - コーディング規約の遵守

3. 必要に応じて、具体的な改善点を指摘する

</details>

<!-- for GitHub Copilot review rule -->