### PR TITLE
[add] リファクタリング計画（plan-refactor）の抽象仕様書・技術設計書を追加

### DIFF
--- a/.sdd/specification/spec-design/plan-refactor_design.md
+++ b/.sdd/specification/spec-design/plan-refactor_design.md
@@ -1,0 +1,487 @@
+---
+id: "design-spec-design-plan-refactor"
+title: "リファクタリング計画"
+type: "design"
+status: "draft"
+sdd-phase: "plan"
+impl-status: "implemented"
+created: "2026-07-08"
+updated: "2026-07-08"
+depends-on: ["spec-spec-design-plan-refactor"]
+tags: ["refactoring", "reverse-engineering", "skill-implementation"]
+category: "spec-design"
+priority: "medium"
+risk: "medium"
+---
+
+# リファクタリング計画 - 技術設計書
+
+**関連 Spec:** [plan-refactor_spec.md](plan-refactor_spec.md)
+**関連 PRD:** [../requirement/spec-design/plan-refactor.md](../requirement/spec-design/plan-refactor.md)
+**実装参照:** `plugins/sdd-workflow/skills/plan-refactor/SKILL.md`
+
+---
+
+# 1. 設計概要
+
+## 1.1. 現在のアーキテクチャ
+
+`/plan-refactor` スキルは Claude Code プラグイン内でエージェント実行される。
+実装の核は以下の2つのユースケースに分かれている：
+
+- **Case A**: 既存設計書がある場合、実装と設計の比較から改善ポイントを特定し、リファクタリング計画を追加
+- **Case B**: 設計書がない場合、実装から設計書を逆生成してから計画を作成
+
+## 1.2. 技術スタック
+
+- **言語**: Markdown（ドキュメント生成）/ Bash（ファイル検索）
+- **実行環境**: Claude Code エージェント実行時
+- **出力形式**: Markdown（front matter 付き）
+- **テンプレートエンジン**: 環境変数置換 + プリミティブなテンプレート処理
+
+---
+
+# 2. アーキテクチャ
+
+## 2.1. コンポーネント構造
+
+```
+plugins/sdd-workflow/skills/plan-refactor/
+├── SKILL.md                      # スキル定義書（入出力・フロー・ルール）
+├── scripts/
+│   ├── scan-existing-docs.sh    # Phase 1: 既存ドキュメント検索
+│   └── find-implementation-files.sh  # Phase 2: 実装ファイル検索
+├── templates/{en,ja}/
+│   ├── reverse_spec_template.md    # Case B: 逆生成仕様書テンプレート
+│   ├── reverse_design_template.md  # Case B: 逆生成設計書テンプレート
+│   ├── refactor_plan_section.md    # Both: リファクタリング計画テンプレート
+│   └── completion_output.md        # 出力フォーマット
+├── examples/
+│   ├── cli_usage.md             # 使用例
+│   ├── case_a_existing_docs.md  # Case A のワークスルー
+│   └── case_b_no_docs.md        # Case B のワークスルー
+└── references/
+    ├── front_matter_spec_design.md     # front matter スキーマ定義
+    ├── design_doc_integration.md       # 設計書統合ガイド
+    └── refactor_patterns.md            # リファクタリングパターン集
+```
+
+## 2.2. データフロー
+
+```
+ユーザー入力
+  ↓
+[フェーズ 1: 事前チェック]
+  - scan-existing-docs.sh → .sdd/.cache/plan-refactor/existing-docs.json
+  - Case A / Case B 判定
+  ↓
+[フェーズ 1.5: ユーザー意図の解析]
+  - context パラメータを解析（オプション）
+  ↓
+[フェーズ 2: 実装ファイル検出]
+  - find-implementation-files.sh → implementation-files.json
+  - ファイル数チェック（20+ の場合、ユーザー確認）
+  - 実装ファイルを読み込む
+  ↓
+[フェーズ 3: 処理分岐]
+  ├─ Case A:
+  │   - 既存設計書を読み込む
+  │   - 実装と設計書の比較分析
+  │   - リファクタリング計画を生成・追記
+  │
+  └─ Case B:
+      - 仕様書テンプレートから逆生成
+      - 設計書テンプレートから逆生成
+      - リファクタリング計画を生成・追記
+  ↓
+[フェーズ 4: 検証]
+  - 必須セクション確認
+  ↓
+[フェーズ 5: 次のステップ]
+  - レビューエージェント推奨
+  ↓
+出力: 設計書 + リファクタリング計画
+```
+
+---
+
+# 3. 実装詳細
+
+## 3.1. Phase 1: Pre-flight Checks
+
+### Step 1.1: Scan for Existing Documents
+
+**実装ファイル**: `scripts/scan-existing-docs.sh`
+
+**処理**:
+1. `.sdd/requirement/{feature-name}.md` → PRD を検索
+2. `.sdd/specification/{feature-name}_spec.md` → 仕様書を検索
+3. `.sdd/specification/{feature-name}_design.md` → 設計書を検索
+4. 階層構造対応：親機能ディレクトリ内のファイルも検索
+5. 結果を `.sdd/.cache/plan-refactor/existing-docs.json` に出力
+
+**出力例**:
+```json
+{
+  "prd_exists": true,
+  "prd_path": ".sdd/requirement/auth.md",
+  "spec_exists": false,
+  "spec_path": null,
+  "design_exists": true,
+  "design_path": ".sdd/specification/auth_design.md"
+}
+```
+
+### Step 1.3: Determine Processing Case
+
+- `design_exists == true` → **Case A** (設計書更新)
+- `design_exists == false` → **Case B** (逆生成)
+
+## 3.2. Phase 1.5: Parse User Intent (Optional)
+
+**入力**: `context` パラメータ（例: "無限スクロール化してパフォーマンス改善"）
+
+**処理**:
+- パラメータがある場合、プロンプトで Claude に解析させる
+- 抽出項目:
+  - Primary Goal: 達成したい主要な改善
+  - Motivation: なぜそれが必要か
+  - Approach: 使用する技術・パターン（オプション）
+
+**利用先**:
+- リファクタリング計画の "Purpose and Background" セクションで優先度付け
+- "Refactoring Strategy" で指定の手法を採用
+- "Business/Technical Drivers" で motivation を記載
+
+## 3.3. Phase 2: Implementation Discovery
+
+### Step 2.1: Find Implementation Files
+
+**実装ファイル**: `scripts/find-implementation-files.sh`
+
+**処理**:
+1. `feature-name` をパターンマッチング
+   - ファイル名に `{feature-name}` を含む
+   - ファイル内容に `{feature-name}` を含む（grep）
+2. `--scope=<dir>` で検索範囲を限定（指定時）
+3. 除外パターン: `node_modules/`, `.git/`, `dist/`, `build/`, `*.test.*`
+4. 結果を `.sdd/.cache/plan-refactor/implementation-files.json` に出力
+
+**出力例**:
+```json
+{
+  "feature": "auth",
+  "file_count": 12,
+  "files": [
+    {
+      "path": "src/services/auth.ts",
+      "relevance": "high",
+      "matches": ["function authenticate", "class AuthService"]
+    }
+  ]
+}
+```
+
+### Step 2.3: Validate File Count
+
+- ファイル数 > 20 かつ `--ci` フラグなし → ユーザー確認ダイアログ
+- 選択肢: Yes / No / Adjust Scope
+- Adjust Scope 選択時 → 新しいスコープを入力させる
+
+### Step 2.4: Read Implementation Files
+
+- `implementation-files.json` から最大10ファイルを優先度順に読み込む
+- 優先度: ファイル名の関連度 > ファイルサイズ
+- テストファイルは除外（初期読み込み時）
+
+## 3.4. Phase 3A: Case A - Existing Design Document
+
+### Step 3A.2: Analyze Implementation vs. Specification
+
+**比較観点**:
+1. 設計書に記載されているコンポーネントが実装に存在するか
+2. 実装がコンポーネント設計に従っているか
+3. 実装に存在するが設計書に記載されていない部分があるか
+
+**抽出内容**:
+- **一致度**: ✓ 完全一致 / ⚠ 部分一致 / ✗ 乖離
+- **乖離内容**: 技術スタック・API・データフロー・エラー処理
+- **技術的負債**: コード重複・密結合・テストカバレッジ不足
+
+### Step 3A.4: Generate Refactoring Plan
+
+**テンプレート**: `templates/${SDD_LANG}/refactor_plan_section.md`
+
+**セクション構成**:
+
+| セクション | 内容 | 必須 |
+|----------|------|------|
+| Purpose and Background | リファクタリングの目的・背景。context がある場合は優先度付け | ✓ |
+| Current State Analysis | 現状の問題点・メトリクス・根本原因。context に関連する項目を強調 | ✓ |
+| Refactoring Strategy | 目標・アプローチ・トレードオフ。context の approach を採用すれば記載 | ✓ |
+| Migration Plan | 段階的タスク・見積もり・依存関係 | ✓ |
+| Impact Analysis | 破壊的変更・影響コンポーネント・ロールバック計画 | ✓ |
+| Testing Strategy | ユニットテスト・統合テスト・E2E テスト計画 | ✓ |
+| Success Criteria | メトリクス・受け入れ基準 | ✓ |
+| Risks and Mitigations | リスク・軽減策 | ✓ |
+| Timeline and Milestones | スケジュール・マイルストーン | - |
+
+**例（context: "無限スクロール化してパフォーマンス改善"）**:
+
+このコンテクストを使用した場合、生成される リファクタリング計画は以下のようになります（SDD_LANG=JA の場合）：
+
+```markdown
+## リファクタリング計画
+
+### 目的と背景
+現在のリスト表示は全アイテムを一度に DOM にレンダリングしているため、
+1000+ アイテムで レンダリング時間が 3 秒以上かかる。
+これを無限スクロール実装により 500ms 以下に改善する。
+
+### 現状分析
+- 全アイテムのデータを メモリに保持（20MB+）
+- 初期ロード時に全 DOM を作成（実装: UserList.tsx:45）
+- スクロールイベントの処理なし
+
+### リファクタリング戦略
+**アプローチ**: react-window による仮想化
+- 動的にビューポート内のアイテムのみレンダリング
+- メモリ使用量を 2MB 以下に削減
+- 初期ロードを 200ms 以下に短縮
+
+...
+```
+
+### Step 3A.5: Update Design Document
+
+**処理**: `Edit {design_path}` で既存設計書の末尾に "## Refactoring Plan" セクションを追記
+
+**前提**: 設計書に "## References" などの最終セクションがない場合のみ末尾に追記。
+既に "## Refactoring Plan" が存在する場合は置換。
+
+## 3.5. Phase 3B: Case B - No Documents (Reverse Engineering)
+
+### Step 3B.1: Reverse-Engineer Specification
+
+**テンプレート**: `templates/${SDD_LANG}/reverse_spec_template.md`
+
+**抽出内容**:
+
+| 項目 | 説明 | 実装参考箇所 |
+|-----|------|-----------|
+| **Feature Name** | 機能の識別子 | パラメータから |
+| **Background** | なぜこの機能が必要か | コミットメッセージ / issue / コード内コメント |
+| **Purpose** | 機能の目的 | 実装の主要 API / エクスポート |
+| **Functional Requirements** | 何ができるのか | 公開 API / インターフェース定義 |
+| **Data Model** | データ型・エンティティ | 型定義 / データベーススキーマ |
+| **Behavior** | 主要なユースケース・フロー | 実装の核となるアルゴリズム |
+
+**生成規則**:
+```markdown
+---
+id: "spec-{feature-name}"
+title: "{FEATURE_NAME}"
+type: "spec"
+status: "review"           # 逆生成は review 状態
+sdd-phase: "specify"
+created: "YYYY-MM-DD"
+updated: "YYYY-MM-DD"
+depends-on: ["prd-{feature-name}"]  # PRD があれば指定
+tags: ["reverse-engineered"]
+---
+
+> **⚠️ 注意**: この仕様書は{DATE}時点の実装から逆生成されたものです。
+> 元々の設計ではなく、現在の実装の文書化です。内容を確認の上、
+> 必要に応じて更新してください。
+```
+
+### Step 3B.3: Reverse-Engineer Design Document
+
+**テンプレート**: `templates/${SDD_LANG}/reverse_design_template.md`
+
+**抽出内容**:
+
+| 項目 | 説明 | 実装参考箇所 |
+|-----|------|-----------|
+| **Architecture Overview** | 高レベルアーキテクチャ | ディレクトリ構造 / モジュール設計 |
+| **Component Structure** | コンポーネント一覧 | ファイル / クラス / 関数構成 |
+| **Data Flow** | データの流れ | 呼び出し関係 / イベントハンドリング |
+| **Key Algorithms** | 重要なアルゴリズム | 複雑な処理・計算ロジック |
+| **API Design** | インターフェース設計 | 公開関数・エンドポイント・型定義 |
+| **Error Handling** | エラー処理戦略 | 例外処理 / エラーコード |
+| **Testing Strategy** | テスト構成 | テストファイル有無・カバレッジ |
+| **Technical Debt** | 観測された負債項目 | コード重複・硬い結合・古いパターン |
+
+**生成規則**:
+```markdown
+---
+id: "design-{feature-name}"
+title: "{FEATURE_NAME}"
+type: "design"
+status: "review"            # 逆生成は review 状態
+sdd-phase: "plan"
+impl-status: "implemented"  # 既に実装済み
+created: "YYYY-MM-DD"
+updated: "YYYY-MM-DD"
+depends-on: ["spec-{feature-name}"]
+tags: ["reverse-engineered"]
+---
+
+> **⚠️ 注意**: この設計書は{DATE}時点の実装から逆生成されたものです。
+> 現在の状態を文書化したものであり、元々の設計ではありません。
+> 内容を確認の上、必要に応じて更新してください。
+```
+
+### Step 3B.5: Generate Refactoring Plan
+
+Case A と同じ流れで「## Refactoring Plan」セクションを作成・追記
+
+---
+
+# 4. テンプレート管理
+
+## 4.1. テンプレートの場所と優先度
+
+### テンプレート検索順序
+
+1. **プロジェクト定義テンプレート** (最優先)
+   - `.sdd/SPECIFICATION_TEMPLATE.md`
+   - `.sdd/DESIGN_DOC_TEMPLATE.md`
+
+2. **プラグイン言語別テンプレート**
+   - `plugins/sdd-workflow/skills/plan-refactor/templates/${SDD_LANG:-en}/`
+
+3. **フォールバック** (推奨されない)
+   - プラグイン EN テンプレート
+
+### front matter スキーマ
+
+**Spec front matter**:
+```yaml
+id: "spec-{feature-name}"
+type: "spec"
+status: "draft" or "review"
+sdd-phase: "specify"
+depends-on: ["prd-{feature-name}"] or []
+tags: ["reverse-engineered"] (if Case B)
+```
+
+**Design front matter**:
+```yaml
+id: "design-{feature-name}"
+type: "design"
+status: "draft" or "review"
+sdd-phase: "plan"
+impl-status: "implemented" or "not-implemented"
+depends-on: ["spec-{feature-name}"]
+tags: ["reverse-engineered"] (if Case B)
+```
+
+---
+
+# 5. エラーハンドリング
+
+| 状況 | 対応 |
+|-----|------|
+| 実装ファイルが見つからない | ユーザーに feature-name を確認。`--scope` の指定を推奨 |
+| 20+ ファイル検出 | CI モードでない場合、確認ダイアログ表示。スコープ調整を提案 |
+| context が曖昧 | `AskUserQuestion` で Primary Goal / Motivation を確認 |
+| PRD / 既存設計書が複数存在 | 最新の mtime を持つものを採用 |
+| テンプレートが見つからない | プラグイン EN テンプレートにフォールバック |
+
+---
+
+# 6. テスト戦略
+
+## 6.1. ユニットテスト
+
+- `tests/skills/plan-refactor/` 配下
+- scan-existing-docs.sh の正確性（複数構造・ファイル名パターン）
+- find-implementation-files.sh のマッチング精度
+
+## 6.2. 統合テスト
+
+- Case A: 既存設計書がある機能で実行 → 設計書更新を確認
+- Case B: 設計書がない機能で実行 → spec / design 生成を確認
+- context パラメータ付き実行 → 計画に反映されたか確認
+
+## 6.3. マニュアルテスト
+
+- 実際のプロジェクトで実行
+- レビューエージェントで品質確認
+
+---
+
+# 7. 言語対応（SDD_LANG）
+
+- **EN**: 英語テンプレート・出力
+- **JA**: 日本語テンプレート・出力
+
+テンプレートパス: `templates/${SDD_LANG:-en}/`
+
+---
+
+# 8. デプロイ・リリース
+
+- プラグイン `sdd-workflow` の一部として配布
+- スキル `.claude-plugin/plugin.json` に登録
+- ドキュメント: `SKILL.md`, テンプレート, examples, references
+
+---
+
+# 9. 設計判断の記録
+
+### Decision 1: Case A/B の分岐設計
+
+**判断**: 既存設計書の有無で異なる処理流を採用
+
+**理由**:
+- 既存設計書がある場合、逆生成より既存設計の更新が効率的
+- 設計書がない場合、テンプレートから逆生成して明確な文書を作成
+
+**代替案**:
+- 常に逆生成 → 既存設計書を上書きしてしまいデータ喪失のリスク
+- 常に既存ドキュメント参照 → 新規機能に対応不可
+
+**トレードオフ**:
+- ロジック複雑性 ↑ / 安全性・柔軟性 ↑
+
+### Decision 2: context パラメータのオプション化
+
+**判断**: context は必須でなくオプション
+
+**理由**:
+- 自動分析で一般的な改善提案も可能
+- context を指定することでより焦点を絞った計画が作成可能
+- ユーザーの使い勝手が向上
+
+**実装上の複雑性**: context 有無で異なるプロンプトを用意
+
+### Decision 3: 20+ ファイルチェック
+
+**判断**: 実装ファイルが多い場合、ユーザー確認を必須に
+
+**理由**:
+- 分析時間の増加を予防
+- 不要なファイル読み込みを避ける（--scope で最適化可能）
+
+**代替案**:
+- 固定値でフィルタリング → ユーザー意図を反映できない
+- 常にすべて読む → スケール問題
+
+---
+
+# 10. 今後の拡張
+
+- **実行時挙動分析**: コードカバレッジツールとの連携で動的情報を補完
+- **差分レポート生成**: 設計書と実装の差分を図示
+- **マイグレーション支援**: リファクタリング計画の自動タスク化・実装テンプレート生成
+
+---
+
+# 参照
+
+- **親 PRD**: [../requirement/spec-design/index.md](../requirement/spec-design/index.md)
+- **AI-SDD 原則**: [../../AI-SDD-PRINCIPLES.md](../../AI-SDD-PRINCIPLES.md)
+- **スキル SKILL.md**: [../../../plugins/sdd-workflow/skills/plan-refactor/SKILL.md](../../../plugins/sdd-workflow/skills/plan-refactor/SKILL.md)
+- **テンプレート**: [../../../plugins/sdd-workflow/skills/plan-refactor/templates/](../../../plugins/sdd-workflow/skills/plan-refactor/templates/)

--- a/.sdd/specification/spec-design/plan-refactor_spec.md
+++ b/.sdd/specification/spec-design/plan-refactor_spec.md
@@ -1,0 +1,208 @@
+---
+id: "spec-spec-design-plan-refactor"
+title: "リファクタリング計画"
+type: "spec"
+status: "draft"
+sdd-phase: "specify"
+created: "2026-07-08"
+updated: "2026-07-08"
+depends-on: ["prd-spec-design-plan-refactor"]
+tags: ["refactoring", "reverse-engineering", "design-doc"]
+category: "spec-design"
+priority: "medium"
+risk: "medium"
+---
+
+# リファクタリング計画 - 抽象仕様書
+
+**関連 Design Doc:** [plan-refactor_design.md](plan-refactor_design.md)
+**関連 PRD:** [../requirement/spec-design/plan-refactor.md](../requirement/spec-design/plan-refactor.md)
+**親 PRD:** [../requirement/spec-design/index.md](../requirement/spec-design/index.md)
+
+---
+
+# 1. 背景
+
+仕様書が存在しない既存機能に対しても、実装コードの分析から設計書を逆算・整備し、リファクタリング計画を立案できることが求められている。これにより、既存実装の設計意図を文書化し、改善戦略を体系的に立案することが可能になる。
+
+# 2. 概要
+
+本機能は、既存実装の技術詳細を分析し、設計書の作成・更新とリファクタリング計画の立案を行う。
+開発者が対象機能を指定し、任意で改善目標を入力することで、以下を実現する：
+
+- **既存実装の分析**: 実装コードから技術スタック・アーキテクチャ・データフロー・アルゴリズムを抽出
+- **設計書の作成・更新**: 実装を正確に記述した技術設計書を作成、または既存設計書を更新
+- **リファクタリング計画の立案**: 技術的負債を特定し、改善戦略・段階的実装計画を提案
+
+---
+
+# 3. 要求定義
+
+## 3.1. 機能要件 (Functional Requirements)
+
+| ID     | 要件 | 優先度 | 根拠 |
+|--------|------|------|------|
+| FR_001 | 既存実装を分析し、実装に基づく技術設計書を作成・更新する | 必須 | **PRD FR_001** を実装。親 PRD UR_004 から派生。仕様書が存在しない機能にも対応する必要がある |
+| FR_002 | 作成・更新された設計書をベースに、リファクタリング計画を立案する | 必須 | **PRD FR_001** を実装。親 PRD UR_004。改善戦略・段階的タスク・リスク分析を含める |
+| FR_003 | 分析対象をディレクトリ指定で絞り込める（スコープ指定） | オプション | 大規模プロジェクトで不要なファイルを除外するため |
+| FR_004 | 開発者が改善目標を入力し、目標に沿った計画を立案できる | オプション | より焦点を絞ったリファクタリング計画の実現 |
+
+## 3.2. 非機能要件 (Non-Functional Requirements)
+
+| ID      | カテゴリ | 要件 | 目標値 |
+|---------|------|------|------|
+| NFR_001 | 言語対応 | 生成される設計書・計画の言語が `SDD_LANG` 環境変数に従う | EN/JA 両言語対応 |
+| NFR_002 | 命名規則準拠 | 生成される設計書は `{name}_design.md` サフィックスとテンプレート構造に準拠 | 親 PRD IR_001 |
+| NFR_003 | スケーラビリティ | 大規模実装（20+ ファイル）の場合、確認ダイアログを表示し対話的に絞り込み可能 | ユーザー体験向上 |
+
+---
+
+# 4. 提供コンポーネント
+
+本機能は Claude Code プラグイン「sdd-workflow」のスキルとして提供される。
+
+| 種別 | 配置場所 | 名前 | 概要 |
+|-----|------|------|------|
+| skill | `plugins/sdd-workflow/skills/plan-refactor/` | `/plan-refactor` | 既存実装を分析し、設計書とリファクタリング計画を作成 |
+
+## 4.1. 入出力定義
+
+### 入力パラメータ
+
+```
+/plan-refactor <feature-name> [context] [--scope=<dir>] [--ci]
+```
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `feature-name` | string | ✓ | 対象機能の識別子（ファイル名またはパス） |
+| `context` | string | - | 改善目標・意図（例: "無限スクロール化してパフォーマンス改善"） |
+| `--scope=<dir>` | string | - | ファイル検索のスコープ（例: `src/components/`） |
+| `--ci` | flag | - | CI/自動実行モード（ユーザー確認を省略） |
+
+### 出力
+
+| 出力物 | 形式 | 説明 |
+|-------|-----|------|
+| 技術設計書 | `.sdd/specification/{category}/{feature-name}_design.md` | 既存実装に基づく設計書。新規作成または既存を更新 |
+| リファクタリング計画 | 設計書内の "## リファクタリング計画" セクション | 改善戦略・段階的タスク・リスク分析・テスト戦略を含む |
+
+---
+
+# 5. 用語集
+
+| 用語 | 説明 |
+|-----|------|
+| **逆生成（reverse engineering）** | 実装コードから仕様・設計書を抽出し、文書化するプロセス |
+| **技術的負債** | 改善が必要な実装上の問題（密結合・コード重複・テストカバレッジ不足など） |
+| **リファクタリング計画** | 技術的負債を解消するための改善戦略・段階的実装タスク・リスク評価 |
+| **スコープ指定** | 分析対象を特定のディレクトリに限定し、不要なファイルを除外する機能 |
+
+---
+
+# 6. 使用例
+
+```bash
+# 基本的な使用（自動分析）
+/plan-refactor user-list
+
+# 改善目標を指定（焦点を絞ったリファクタリング計画）
+/plan-refactor user-list "無限スクロール化してパフォーマンス改善"
+
+# スコープを限定
+/plan-refactor checkout-flow --scope=src/components/checkout
+
+# 複合形式
+/plan-refactor auth-module "依存性注入を導入してテスト容易性を向上" --scope=src/services/auth
+```
+
+---
+
+# 7. 振る舞い図
+
+## 7.1. ユースケース図
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart LR
+    Developer((開発者))
+
+    subgraph PlanRefactor["リファクタリング計画"]
+        AnalyzeImpl([既存実装を分析])
+        CreateDesign([設計書を作成・更新])
+        CreatePlan([リファクタリング計画を作成])
+        SpecifyScope([対象範囲を指定])
+    end
+
+    Developer --> AnalyzeImpl
+    Developer --> SpecifyScope
+    CreateDesign -->|包含| AnalyzeImpl
+    CreatePlan -->|包含| AnalyzeImpl
+    SpecifyScope -->|拡張: スコープ絞り込み| AnalyzeImpl
+```
+
+## 7.2. フロー図
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+flowchart TD
+    Start([開始]) --> Input["入力: feature-name, context?, scope?, ci-flag?"]
+    Input --> ScanExist{"既存ドキュメント確認"}
+    
+    ScanExist -->|Case A: 設計書存在| CaseA["既存設計書を読み込む"]
+    ScanExist -->|Case B: 設計書不在| CaseB["逆生成スペックを作成"]
+    
+    CaseA --> FindImpl["実装ファイルを検索"]
+    CaseB --> FindImpl
+    
+    FindImpl --> LargeImpl{"20+ ファイル?"}
+    LargeImpl -->|Yes, 非CI| AskScope["スコープ確認ダイアログ"]
+    LargeImpl -->|No or CI| ReadImpl["実装ファイルを読み込む"]
+    AskScope --> ReadImpl
+    
+    ReadImpl --> Analyze["実装を分析<br/>- アーキテクチャ<br/>- データフロー<br/>- 技術的負債"]
+    
+    Analyze --> UpdateDesign["設計書を作成・更新"]
+    UpdateDesign --> CreatePlan["リファクタリング計画を生成<br/>- 目的・背景<br/>- 現状分析<br/>- 戦略<br/>- 段階的タスク<br/>- リスク分析<br/>- テスト戦略"]
+    
+    CreatePlan --> Review["(オプション) レビューエージェント起動"]
+    Review --> Output["設計書・計画を出力"]
+    Output --> End([完了])
+```
+
+---
+
+# 8. 制約事項
+
+- **技術的制約**: 実装分析は静的なコード読解に基づき、実行時挙動の解析は含まない
+- **スコープ**: リファクタリング計画の作成は、設計書の作成・更新と同時に行われ、設計書の別ファイルでは管理されない
+- **言語**: 出力は `SDD_LANG` に従い、ドキュメント内で言語を混在させない
+- **命名規則**: 生成される設計書は必ず `_design.md` サフィックスを含み、DESIGN_DOC_TEMPLATE.md に準拠する
+
+---
+
+# 9. 原則との整合性
+
+| 原則ID | 原則名 | 本仕様への適用内容 |
+|-------|-----|-----------|
+| A-001 | Skills-First | `/plan-refactor` をスキルとして実装し、Claude Code プラグインの標準機構で起動可能にする（セクション 4） |
+| A-002 | フックとスクリプトの責務分離 | ファイル検索・既存ドキュメント確認を Bash スクリプト化し、エージェント起動時に活用（セクション 2） |
+| B-001 | Vibe Coding 防止 | 既存実装を正確に分析し、文書化することで、設計の意図を明確化し、改善判断の根拠を強化する |
+| B-002 | 多言語対応の一貫性 | 生成物の言語は SDD_LANG に従い、テンプレート・出力は EN/JA 両言語で同等の構成を維持 |
+| D-001 | 抽象度の分離 | 技術設計書には実装詳細（アーキテクチャ・技術スタック・アルゴリズム）を記述し、設計判断の理由を明示 |
+| D-002 | 設計判断の透明性 | リファクタリング計画に改善戦略・選択肢・トレードオフを明示し、判断根拠を記録 |
+| D-003 | ドキュメント永続性ルール | 技術的負債分析をリファクタリング計画に統合し、知見を永続化する（セクション 5） |
+
+---
+
+# トレーサビリティ表
+
+## PRD 要件への対応
+
+| PRD要件 | 本仕様への対応 | 実装箇所 |
+|---------|-----------|---------|
+| UR_004: 既存実装から設計書を整備しリファクタリングを計画できる | FR_001, FR_002 による完全対応 | 4. 提供コンポーネント |
+| FR_004: 既存実装を分析し設計書とリファクタリング計画を作成する | FR_001, FR_002 による完全対応 | 4. 提供コンポーネント |
+| IR_001: 命名規則・テンプレート・front matter への準拠 | FR_001 で設計書生成時に強制 | 4.1. 入出力定義 |
+| DC_001: 抽象度の分離 | 設計書に技術詳細を含め、仕様との分離を保証 | 8. 制約事項 |
+| DC_002: 言語の一貫性 | NFR_001 で SDD_LANG に従う | 3.2. 非機能要件 |


### PR DESCRIPTION
## 概要

spec-design カテゴリの子PRD「リファクタリング計画」について、AI-SDD ワークフローに従い抽象仕様書（`_spec.md`）と技術設計書（`_design.md`）を生成する。既存実装（`/plan-refactor` スキル）を真実の源として逆算し、トリガー方式・処理フロー・テンプレート管理・設計判断を正確に反映した。

## 変更内容

- [x] `plan-refactor_spec.md` を追加（既存実装分析・設計書逆算・リファクタリング計画立案の抽象仕様）
- [x] `plan-refactor_design.md` を追加（Case A/B 分岐・5フェーズ処理フロー・設計判断の記録）
- [x] トレーサビリティ表に親PRD要求ID（UR_004 / FR_001 / IR_001 / DC_001 / DC_002）を記載
- [x] front matter を指定の id / depends-on で設定（上流方向のみ）
- [x] spec-reviewer / front-matter-reviewer のレビュー指摘を反映

## レビューの焦点

- **既存実装との整合性**: `plugins/sdd-workflow/skills/plan-refactor/SKILL.md` の挙動（Case A/B 分岐、20+ファイル確認、context パラメータ解析）が design に正確に反映されているか
- **抽象度の分離（DC_001）**: spec に技術詳細を含めず、design 側に集約できているか
- **トレーサビリティ**: 親PRD → 子PRD → spec → design の依存方向が保たれているか

## テスト計画

- [x] `cat plugins/*/.claude-plugin/*.json | jq .` JSON構文チェック通過
- [ ] `claude --plugin-dir ./plugins/sdd-workflow` でローカルテスト確認
- [x] Markdownリンクの整合性確認

## 参考資料

- Closes #124
- 子PRD: `.sdd/requirement/spec-design/plan-refactor.md`
- 親PRD: `.sdd/requirement/spec-design/index.md`

<!-- for GitHub Copilot review rule -->

<details>
<summary>for GitHub Copilot review rule</summary>

## お願い

- 日本語で回答してください
- 簡潔で分かりやすい説明を心がけてください
- ベストプラクティスの具体例を提示してください
- 指摘の根拠となる情報源や学習リソースの提案を積極的に行ってください

## レビュールール

以下のプレフィックスを使用してレビューコメントを分類してください：

- `[must]` - 必須修正項目（セキュリティ、バグ、重大な設計問題）
- `[recommend]` - 推奨修正項目（パフォーマンス、可読性の大幅改善）
- `[nits]` - 軽微な指摘（コードスタイル、タイポ等）

## レビューステップ

1. コードの差分よりPRの概要を作成する

2. 実際にコードを確認し、以下の観点でレビューを行う
  - コードの正確性
  - パフォーマンス
  - セキュリティ
  - 可読性
  - 保守性
  - コーディング規約の遵守

3. 必要に応じて、具体的な改善点を指摘する

</details>

<!-- for GitHub Copilot review rule -->