### PR TITLE
[remove] READMEから参照先が存在しないCIバッジを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ai-sdd-workflow
 
-[![CI](https://github.com/ToshikiImagawa/ai-sdd-workflow/actions/workflows/ci.yml/badge.svg)](https://github.com/ToshikiImagawa/ai-sdd-workflow/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
 


### PR DESCRIPTION
## 概要

CIワークフロー削除（`b0bdad9`）により参照先が存在しなくなったCIステータスバッジをREADMEから除去する。バッジのリンク切れ・失敗表示を解消するためのフォローアップ対応。

## 変更内容

- [x] README冒頭のCIステータスバッジ（`ci.yml` へのリンク）を削除

## レビューの焦点

- `README.md`: CIバッジ1行の削除のみ。License / Platform バッジは維持されていること

## テスト手順

- 該当リポジトリにCIワークフローが存在しないこと（`.github/workflows/ci.yml` が無い）を確認済み
- README のバッジ表示がリンク切れにならないこと

## 参考資料

- 関連コミット: `b0bdad9` [remove] Remove legacy configuration files, outdated documentation, and CI workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)